### PR TITLE
Fix bare catch, deadlocking sync call, and duplicate event handler registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to Morpheus will be documented in this file.
+
+## [Unreleased]
+
+### Fixed
+- Fixed bare `catch { }` in `HelpModule.cs` that silently swallowed all exceptions
+  when reading `RateLimitAttribute` field values. Now catches only
+  `InvalidCastException` and `TargetException`.
+- Removed dead code `ValidateDays` method from `LevelsModule.cs` that contained a
+  synchronous blocking call (`GetAwaiter().GetResult()`) on an async method,
+  which posed a deadlock risk.
+- Fixed `InteractionsHandler` registering a separate Discord event handler for
+  every registered interaction. Now uses a single router that dispatches to the
+  correct handler by custom ID, preventing redundant handler invocations on
+  every interaction event.
+
+### Added
+- Initial changelog file.

--- a/Handlers/InteractionsHandler.cs
+++ b/Handlers/InteractionsHandler.cs
@@ -4,10 +4,29 @@ namespace Morpheus.Handlers;
 public class InteractionsHandler(DiscordSocketClient client)
 {
     static readonly Dictionary<string, Func<SocketInteraction, Task>> InteractionIds = [];
+    private static bool _routedRegistered;
 
     public void RegisterInteraction(string id, Func<SocketInteraction, Task> func)
     {
-        if (InteractionIds.TryAdd(id, func))
-            client.InteractionCreated += func;
+        if (!InteractionIds.TryAdd(id, func))
+            return;
+
+        if (!_routedRegistered)
+        {
+            client.InteractionCreated += RouteInteraction;
+            _routedRegistered = true;
+        }
+    }
+
+    private static async Task RouteInteraction(SocketInteraction interaction)
+    {
+        if (interaction is SocketMessageComponent messageComponent)
+        {
+            string customId = messageComponent.Data.CustomId;
+            if (customId != null && InteractionIds.TryGetValue(customId, out var handler))
+            {
+                await handler(interaction);
+            }
+        }
     }
 }

--- a/Modules/HelpModule.cs
+++ b/Modules/HelpModule.cs
@@ -191,7 +191,14 @@ public class HelpModule : ModuleBase<SocketCommandContextExtended>
                         var seconds = (int)intFields[1].GetValue(rateAttrInstance)!;
                         rateLimitText = $"{uses} use(s) per {seconds} second(s)";
                     }
-                    catch { rateLimitText = "Rate limit present"; }
+                    catch (InvalidCastException)
+                    {
+                        rateLimitText = "Rate limit present";
+                    }
+                    catch (TargetException)
+                    {
+                        rateLimitText = "Rate limit present";
+                    }
                 }
                 else
                 {

--- a/Modules/LevelsModule.cs
+++ b/Modules/LevelsModule.cs
@@ -1098,17 +1098,6 @@ public class LevelsModule(DB dbContext) : ModuleBase<SocketCommandContextExtende
         return ownerId != 0 && Context.User != null && Context.User.Id == ownerId;
     }
 
-    private bool ValidateDays(int days)
-    {
-        int maxDays = Env.Get<int>("ACTIVITY_GRAPHS_MAX_DAYS", 90);
-        if (!IsOwner() && (days <= 0 || days > maxDays))
-        {
-            ReplyAsync($"Please provide a number of days between 1 and {maxDays}.").GetAwaiter().GetResult();
-            return false;
-        }
-        return true;
-    }
-
     private DateTime GetStartDate(int days) => DateTime.UtcNow.Date.AddDays(-(days - 1));
 
     private DateTime NormalizeToUtc(DateTime dt) => DateTime.SpecifyKind(dt, DateTimeKind.Utc);


### PR DESCRIPTION
## Summary

Three code quality fixes discovered during routine maintenance:

### 1. Bare `catch { }` → specific exception types (HelpModule.cs)
The `RateLimitAttribute` field reader was swallowing all exceptions silently with a bare `catch { }`. Replaced with `InvalidCastException` and `TargetException` so unexpected errors (e.g. `NullReferenceException`, `SecurityException`) are no longer hidden.

### 2. Removed dead code with `.GetAwaiter().GetResult()` (LevelsModule.cs)
The `ValidateDays` method was never called by any command handler (all call sites use inline validation with proper async `ReplyAsync`). Removed the dead code, which also eliminates the synchronous blocking call `.GetAwaiter().GetResult()` that could cause deadlocks in ASP.NET-like synchronization contexts.

### 3. Fixed InteractionsHandler redundant event subscriptions (InteractionsHandler.cs)
`RegisterInteraction` was subscribing a separate `client.InteractionCreated` handler for every registered interaction, causing all handlers to fire on every interaction event. Now uses a single router that dispatches to the correct handler by custom ID.

### 4. Added CHANGELOG.md
Tracks user-visible changes going forward.

## Testing
- `dotnet build`: 0 errors
- All existing warnings are pre-existing (migration naming, nullable annotations, unused parameters)

---

*This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.*