### PR TITLE
test: make economy tests globalization-invariant

### DIFF
--- a/Morpheus.Tests/EconomyServiceTests.cs
+++ b/Morpheus.Tests/EconomyServiceTests.cs
@@ -5,6 +5,14 @@ namespace Morpheus.Tests;
 
 public class EconomyServiceTests
 {
+    private static CultureInfo CreateCommaDecimalCulture()
+    {
+        var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        culture.NumberFormat.NumberDecimalSeparator = ",";
+        culture.NumberFormat.NumberGroupSeparator = ".";
+        return culture;
+    }
+
     [Fact]
     public void OrderUserIdsForUpdate_DeduplicatesAndSortsIds()
     {
@@ -19,7 +27,7 @@ public class EconomyServiceTests
         CultureInfo originalCulture = CultureInfo.CurrentCulture;
         try
         {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            CultureInfo.CurrentCulture = CreateCommaDecimalCulture();
 
             string formatted = EconomyService.FormatMoneyForStorage(1234.5m);
 
@@ -37,7 +45,7 @@ public class EconomyServiceTests
         CultureInfo originalCulture = CultureInfo.CurrentCulture;
         try
         {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            CultureInfo.CurrentCulture = CreateCommaDecimalCulture();
 
             decimal parsed = EconomyService.ParseMoneyFromStorage("1,234.50", fallback: 99m);
 
@@ -55,7 +63,7 @@ public class EconomyServiceTests
         CultureInfo originalCulture = CultureInfo.CurrentCulture;
         try
         {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            CultureInfo.CurrentCulture = CreateCommaDecimalCulture();
 
             decimal parsed = EconomyService.ParseMoneyFromStorage("1234,50", fallback: 99m);
 


### PR DESCRIPTION
## Summary
- Replace `fr-FR` culture lookups in `EconomyServiceTests` with a cloned invariant culture configured to use comma decimals.
- Keeps the tests' non-invariant decimal separator coverage while allowing them to run when .NET globalization-invariant mode is enabled.

## Verification
- `DOTNET_CLI_UI_LANGUAGE=en dotnet test --logger "console;verbosity=minimal" --filter EconomyServiceTests` — passed: 5/5 tests.
- `DOTNET_CLI_UI_LANGUAGE=en dotnet build` — passed with existing package warnings.
- `DOTNET_CLI_UI_LANGUAGE=en dotnet test --logger "console;verbosity=minimal"` — passed: 136/136 tests.
- `git diff --check` — passed.

## Risk
- Low. This only changes test setup culture construction and does not alter production code.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
