### PR TITLE
docs: correct .NET target version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ dotnet build
 
 ## Development setup
 
-- Requires .NET 8 SDK and a Python 3 interpreter on your PATH.
+- Requires .NET 10 SDK and a Python 3 interpreter on your PATH.
 - Optional: `dotnet-ef` tools if you will add migrations.
 
 Install dotnet-ef (if needed):
@@ -51,7 +51,7 @@ If the change needs a manual database migration for production, explain it in th
 
 ## Coding style and expectations
 
-- Language: C# targeting .NET 8.
+- Language: C# targeting .NET 10.
 - Use the project's existing style for naming, nullability annotations, and dependency injection patterns.
 - Prefer small, focused PRs. Unit tests are not required, but are nice to have. 
 - If you change public behavior (commands, DB schema, bot permissions), document it in the PR description.


### PR DESCRIPTION
## Summary
- Correct the contributor SDK requirement and C# target version from .NET 8 to .NET 10.
- Align the guide with the `net10.0` targets in both project files.

## Verification
- `dotnet build` — passed: solution built successfully (existing NU1903 warning for transitive `SQLitePCLRaw.lib.e_sqlite3` remains).
- `dotnet test` — passed: 136 passed, 0 failed, 0 skipped.
- `git diff --check upstream/develop...HEAD` — passed.

## Risk
- Low: documentation-only correction; no runtime behavior or dependencies changed.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
