### PR TITLE
fix: preserve case-sensitive RSS feed paths

### DIFF
--- a/Morpheus.Tests/SubscriptionInputParserTests.cs
+++ b/Morpheus.Tests/SubscriptionInputParserTests.cs
@@ -75,4 +75,15 @@ public class SubscriptionInputParserTests
             ["https://EXAMPLE.com/Feed.xml", "https://example.com/feed.xml"],
             parsed.Select(source => source.Url));
     }
+
+    [Fact]
+    public void ParseRssSources_PreservesCaseSensitivePathsInSpaceSeparatedUrls()
+    {
+        IReadOnlyList<SubscriptionInputParser.RssSource> parsed = SubscriptionInputParser.ParseRssSources(
+            "https://example.com/Feed.xml https://example.com/feed.xml");
+
+        Assert.Equal(
+            ["https://example.com/Feed.xml", "https://example.com/feed.xml"],
+            parsed.Select(source => source.Url));
+    }
 }

--- a/Morpheus.Tests/SubscriptionInputParserTests.cs
+++ b/Morpheus.Tests/SubscriptionInputParserTests.cs
@@ -64,4 +64,15 @@ public class SubscriptionInputParserTests
         Assert.Equal("https://example.com/feed.xml", parsed.Url);
         Assert.Equal("Example feed", parsed.DisplayName);
     }
+
+    [Fact]
+    public void ParseRssSources_PreservesUrlsWithCaseSensitivePaths()
+    {
+        IReadOnlyList<SubscriptionInputParser.RssSource> parsed = SubscriptionInputParser.ParseRssSources(
+            "https://EXAMPLE.com/Feed.xml\nhttps://example.com/feed.xml\nhttps://example.com/Feed.xml");
+
+        Assert.Equal(
+            ["https://EXAMPLE.com/Feed.xml", "https://example.com/feed.xml"],
+            parsed.Select(source => source.Url));
+    }
 }

--- a/Utilities/SubscriptionInputParser.cs
+++ b/Utilities/SubscriptionInputParser.cs
@@ -44,7 +44,10 @@ internal static partial class SubscriptionInputParser
             string[] tokens = SplitTokens(lines[0]).ToArray();
             string[] urls = tokens.Where(IsHttpUrl).ToArray();
             if (urls.Length > 1)
-                return Deduplicate(urls).Select(url => new RssSource(url, null)).ToArray();
+                return urls
+                    .GroupBy(GetRssUrlKey)
+                    .Select(group => new RssSource(group.First(), null))
+                    .ToArray();
         }
 
         List<RssSource> sources = [];

--- a/Utilities/SubscriptionInputParser.cs
+++ b/Utilities/SubscriptionInputParser.cs
@@ -6,6 +6,13 @@ internal static partial class SubscriptionInputParser
 {
     internal sealed record SourceList(IReadOnlyList<string> Sources, ulong? ChannelId);
     internal sealed record RssSource(string Url, string? DisplayName);
+    private sealed record RssUrlKey(
+        string Scheme,
+        string Host,
+        int Port,
+        string UserInfo,
+        string PathAndQuery,
+        string Fragment);
 
     public static SourceList ParseSources(string input)
     {
@@ -62,9 +69,21 @@ internal static partial class SubscriptionInputParser
         }
 
         return sources
-            .GroupBy(source => source.Url, StringComparer.OrdinalIgnoreCase)
+            .GroupBy(source => GetRssUrlKey(source.Url))
             .Select(group => group.First())
             .ToArray();
+    }
+
+    private static RssUrlKey GetRssUrlKey(string value)
+    {
+        Uri uri = new(value, UriKind.Absolute);
+        return new RssUrlKey(
+            uri.Scheme.ToLowerInvariant(),
+            uri.IdnHost.ToLowerInvariant(),
+            uri.Port,
+            uri.UserInfo,
+            uri.PathAndQuery,
+            uri.Fragment);
     }
 
     private static IEnumerable<string> SplitTokens(string input) => input


### PR DESCRIPTION
## Summary
- keep RSS subscriptions with paths that differ only by case
- still deduplicate equivalent scheme/host casing and exact repeated URLs

## Verification
- `dotnet build` — passed (2 existing NU1903 warnings for SQLitePCLRaw.lib.e_sqlite3 2.1.6)
- `dotnet test --no-build` — passed (153 tests)
- `git diff --check` — passed

## Risk
- Low: the change is limited to RSS bulk-input deduplication and has a focused regression test.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
