### PR TITLE
fix: prevent slots vault overdraw

### DIFF
--- a/Morpheus.Tests/SlotsServiceTests.cs
+++ b/Morpheus.Tests/SlotsServiceTests.cs
@@ -59,6 +59,23 @@ public class SlotsServiceTests
         Assert.Equal(-4_990_000m, result.VaultDelta);
     }
 
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(26, false)]
+    public void Spin_UnderfundedWinCannotOverdrawVault(int roll, bool jackpotDisabled)
+    {
+        const decimal vaultAmount = 1_000m;
+
+        SlotsSpinResult result = slotsService.Spin(10_000m, vaultAmount, roll);
+
+        Assert.Equal(jackpotDisabled, result.IsJackpotDisabled);
+        Assert.Equal(SlotsOutcomeKind.MegaWin, result.Outcome.Kind);
+        Assert.True(result.IsPayoutCapped);
+        Assert.Equal(11_000m, result.GrossWinnings);
+        Assert.Equal(-vaultAmount, result.VaultDelta);
+        Assert.Equal(0m, vaultAmount + result.VaultDelta);
+    }
+
     [Fact]
     public void Spin_PushReturnsBetWithoutTaxOrVaultMovement()
     {

--- a/Services/SlotsService.cs
+++ b/Services/SlotsService.cs
@@ -59,6 +59,14 @@ public sealed class SlotsService
             grossWinnings = bet * selectedOutcome.Multiplier;
         }
 
+        decimal availablePayout = Math.Max(0m, vaultAmount + bet);
+        if (grossWinnings > availablePayout)
+        {
+            grossWinnings = availablePayout;
+            resultDescription += " (Capped)";
+            payoutCapped = true;
+        }
+
         decimal profit = grossWinnings - bet;
         decimal tax = profit > 0 ? profit * TaxRate : 0m;
         decimal netWinnings = grossWinnings - tax;


### PR DESCRIPTION
## Summary
- cap slot payouts at the amount available after adding the current bet, preventing a nonnegative slots vault from being overdrawn
- cover both an underfunded jackpot fallback and a direct Mega Win with regression tests

## Verification
- `dotnet build` — passed (0 errors; existing NU1903 SQLite package vulnerability warning)
- `dotnet test` — passed (154 passed, 0 failed, 0 skipped)
- `git diff --check` — passed

## Risk
- Low: only payouts exceeding the available vault plus the current bet are capped; funded outcomes are unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
