### PR TITLE
fix: strip fragments from Twitch channel URLs

### DIFF
--- a/Modules/SubscriptionsModule.cs
+++ b/Modules/SubscriptionsModule.cs
@@ -923,7 +923,7 @@ public class SubscriptionsModule : ModuleBase<SocketCommandContextExtended>
         }
     }
 
-    private static string ExtractTwitchLogin(string input)
+    internal static string ExtractTwitchLogin(string input)
     {
         input = input.Trim();
 
@@ -932,11 +932,11 @@ public class SubscriptionsModule : ModuleBase<SocketCommandContextExtended>
         if (idx >= 0)
             input = input[(idx + "twitch.tv/".Length)..];
 
-        // Strip any leading @, trailing slash / query, and lowercase.
+        // Strip any leading @, trailing slash, query, or fragment, and lowercase.
         input = input.TrimStart('@').Trim('/');
-        int slash = input.IndexOfAny(['/', '?']);
-        if (slash >= 0)
-            input = input[..slash];
+        int delimiter = input.IndexOfAny(['/', '?', '#']);
+        if (delimiter >= 0)
+            input = input[..delimiter];
 
         return input.ToLowerInvariant();
     }

--- a/Morpheus.Tests/SubscriptionsModuleTests.cs
+++ b/Morpheus.Tests/SubscriptionsModuleTests.cs
@@ -1,0 +1,14 @@
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class SubscriptionsModuleTests
+{
+    [Fact]
+    public void ExtractTwitchLogin_StripsUrlFragment()
+    {
+        string login = SubscriptionsModule.ExtractTwitchLogin("https://twitch.tv/Streamer#about");
+
+        Assert.Equal("streamer", login);
+    }
+}


### PR DESCRIPTION
## Summary
- strip URL fragments before resolving or matching Twitch channel logins
- add a regression test for full Twitch channel URLs containing fragments

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter FullyQualifiedName~SubscriptionsModuleTests` — passed (1 test)
- `dotnet build --no-restore` — passed (1 pre-existing NU1903 warning)
- `dotnet test --no-build --no-restore` — passed (157 tests)
- `git diff --check` — passed

## Risk
- Low: the change only extends the existing Twitch URL delimiter handling to include fragments.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
