### PR TITLE
fix: retry failed Twitch go-live notifications

### DIFF
--- a/Jobs/TwitchLiveJob.cs
+++ b/Jobs/TwitchLiveJob.cs
@@ -34,39 +34,50 @@ public class TwitchLiveJob(DB db, TwitchService twitch, DiscordWebhookService di
 
         foreach (TwitchSubscription sub in subscriptions)
         {
-            bool isLiveNow = live.TryGetValue(sub.TwitchUserId, out TwitchService.TwitchStream? stream);
-
-            if (isLiveNow && stream != null)
-            {
-                // Announce only on a fresh stream (not one we've already posted about).
-                if (sub.LastAnnouncedStreamId != stream.Id)
-                {
-                    await AnnounceAsync(sub, stream);
-                    sub.LastAnnouncedStreamId = stream.Id;
-                    changed = true;
-                }
-
-                if (!sub.IsLive)
-                {
-                    sub.IsLive = true;
-                    changed = true;
-                }
-            }
-            else if (sub.IsLive)
-            {
-                sub.IsLive = false;
-                changed = true;
-            }
+            live.TryGetValue(sub.TwitchUserId, out TwitchService.TwitchStream? stream);
+            changed |= await UpdateSubscriptionAsync(sub, stream, AnnounceAsync);
         }
 
         if (changed)
             await db.SaveChangesAsync();
     }
 
-    private async Task AnnounceAsync(TwitchSubscription sub, TwitchService.TwitchStream stream)
+    internal static async Task<bool> UpdateSubscriptionAsync(
+        TwitchSubscription sub,
+        TwitchService.TwitchStream? stream,
+        Func<TwitchSubscription, TwitchService.TwitchStream, Task<bool>> announceAsync)
+    {
+        bool changed = false;
+
+        if (stream != null)
+        {
+            // Record a stream only after Discord accepts the notification. A failed delivery is
+            // retried on the next poll instead of being silently treated as announced.
+            if (sub.LastAnnouncedStreamId != stream.Id && await announceAsync(sub, stream))
+            {
+                sub.LastAnnouncedStreamId = stream.Id;
+                changed = true;
+            }
+
+            if (!sub.IsLive)
+            {
+                sub.IsLive = true;
+                changed = true;
+            }
+        }
+        else if (sub.IsLive)
+        {
+            sub.IsLive = false;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private async Task<bool> AnnounceAsync(TwitchSubscription sub, TwitchService.TwitchStream stream)
     {
         if (sub.Webhook == null)
-            return;
+            return false;
 
         string title = string.IsNullOrWhiteSpace(stream.Title) ? string.Empty : $"\n{stream.Title}";
         string content = $"🔴 **{sub.TwitchDisplayName}** is now live!{title}\nhttps://www.twitch.tv/{sub.TwitchLogin}";
@@ -74,5 +85,7 @@ public class TwitchLiveJob(DB db, TwitchService twitch, DiscordWebhookService di
         bool ok = await discordWebhook.SendAsync(sub.Webhook.WebhookId, sub.Webhook.Token, content, sub.TwitchDisplayName, sub.AvatarUrl);
         if (!ok)
             logsService.Log($"TwitchLiveJob: failed to post go-live for {sub.TwitchLogin} to channel {sub.ChannelDiscordId}", LogSeverity.Warning);
+
+        return ok;
     }
 }

--- a/Morpheus.Tests/TwitchLiveJobTests.cs
+++ b/Morpheus.Tests/TwitchLiveJobTests.cs
@@ -1,0 +1,52 @@
+using Morpheus.Database.Models;
+using Morpheus.Jobs;
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class TwitchLiveJobTests
+{
+    [Fact]
+    public async Task UpdateSubscriptionAsync_WhenAnnouncementFails_DoesNotRecordStreamId()
+    {
+        TwitchSubscription subscription = new()
+        {
+            IsLive = true,
+            LastAnnouncedStreamId = "previous-stream"
+        };
+        TwitchService.TwitchStream stream = new("current-stream", "Test stream");
+
+        bool changed = await TwitchLiveJob.UpdateSubscriptionAsync(
+            subscription,
+            stream,
+            (_, _) => Task.FromResult(false));
+
+        Assert.False(changed);
+        Assert.Equal("previous-stream", subscription.LastAnnouncedStreamId);
+    }
+
+    [Fact]
+    public async Task UpdateSubscriptionAsync_RetriesFailedAnnouncementUntilItSucceeds()
+    {
+        TwitchSubscription subscription = new();
+        TwitchService.TwitchStream stream = new("current-stream", "Test stream");
+        int attempts = 0;
+
+        Task<bool> AnnounceAsync(TwitchSubscription _, TwitchService.TwitchStream __)
+        {
+            attempts++;
+            return Task.FromResult(attempts > 1);
+        }
+
+        bool firstChanged = await TwitchLiveJob.UpdateSubscriptionAsync(subscription, stream, AnnounceAsync);
+        bool secondChanged = await TwitchLiveJob.UpdateSubscriptionAsync(subscription, stream, AnnounceAsync);
+        bool thirdChanged = await TwitchLiveJob.UpdateSubscriptionAsync(subscription, stream, AnnounceAsync);
+
+        Assert.True(firstChanged);
+        Assert.True(subscription.IsLive);
+        Assert.True(secondChanged);
+        Assert.False(thirdChanged);
+        Assert.Equal(2, attempts);
+        Assert.Equal("current-stream", subscription.LastAnnouncedStreamId);
+    }
+}


### PR DESCRIPTION
## Summary
- preserve Twitch go-live stream IDs after failed Discord webhook deliveries so the next poll retries them
- record the stream ID only after a successful send while continuing to track the streamer as live
- add regression coverage for failure, retry, success, and duplicate suppression

## Verification
- `dotnet test --verbosity minimal` — passed: 158 tests, 0 failures (with the existing NU1903 SQLitePCLRaw vulnerability warning)
- `dotnet build --verbosity minimal` — passed: 0 errors (with the same NU1903 warning)
- `git diff --check` — passed

## Risk
- Low: the change is isolated to Twitch announcement state handling and retains the existing once-per-stream behavior after a successful delivery.

Closes #11

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
