### PR TITLE
fix: handle mixed-case RPS choices

### DIFF
--- a/Modules/MiscModule.cs
+++ b/Modules/MiscModule.cs
@@ -293,7 +293,8 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
     public async Task RockPaperScissors(string choice)
     {
         string[] choices = ["rock", "paper", "scissors"];
-        if (!choices.Contains(choice.ToLower()))
+        choice = NormalizeRockPaperScissorsChoice(choice);
+        if (!choices.Contains(choice))
         {
             await ReplyAsync("Invalid choice. Please choose either `rock`, `paper`, or `scissors`.");
             return;
@@ -319,6 +320,8 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
             return;
         }
     }
+
+    internal static string NormalizeRockPaperScissorsChoice(string choice) => choice.ToLowerInvariant();
 
     [Name("Info")]
     [Summary("Displays information about the bot.")]

--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -1,0 +1,15 @@
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class MiscModuleTests
+{
+    [Theory]
+    [InlineData("ROCK", "rock")]
+    [InlineData("PaPeR", "paper")]
+    [InlineData("ScIsSoRs", "scissors")]
+    public void NormalizeRockPaperScissorsChoice_NormalizesMixedCase(string choice, string expected)
+    {
+        Assert.Equal(expected, MiscModule.NormalizeRockPaperScissorsChoice(choice));
+    }
+}


### PR DESCRIPTION
## Summary
- normalize `rps` player choices before both validation and result comparisons
- add regression coverage for uppercase and mixed-case rock/paper/scissors choices

## Verification
- `dotnet build` — passed (with the existing NU1903 advisory warning for SQLitePCLRaw.lib.e_sqlite3 2.1.6)
- `dotnet test` — passed: 159 tests
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change only normalizes already-valid command input before existing game logic.

Closes #13

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
