### PR TITLE
fix: defer xkcd feed seeding until subscribed

### DIFF
--- a/Jobs/XkcdJob.cs
+++ b/Jobs/XkcdJob.cs
@@ -23,16 +23,19 @@ public class XkcdJob(DB db, DiscordWebhookService discordWebhook, LogsService lo
 
     private record XkcdItem(string Title, string Link);
 
+    internal static bool ShouldFetchFeed(int subscriptionCount) => subscriptionCount > 0;
+
     public async Task Execute(IJobExecutionContext context)
     {
         List<XkcdSubscription> subscriptions = await db.XkcdSubscriptions
             .Include(s => s.Webhook)
             .ToListAsync();
 
-        // Nothing to post to and nothing seeded yet — cheap early exit until someone subscribes.
-        bool hasSeen = await db.XkcdSeen.AnyAsync();
-        if (subscriptions.Count == 0 && hasSeen)
+        // Leave the feed unseeded until there is somewhere to post the initial comic.
+        if (!ShouldFetchFeed(subscriptions.Count))
             return;
+
+        bool hasSeen = await db.XkcdSeen.AnyAsync();
 
         List<XkcdItem> items;
         try

--- a/Morpheus.Tests/XkcdJobTests.cs
+++ b/Morpheus.Tests/XkcdJobTests.cs
@@ -1,0 +1,15 @@
+using Morpheus.Jobs;
+
+namespace Morpheus.Tests;
+
+public class XkcdJobTests
+{
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(5, true)]
+    public void ShouldFetchFeed_RequiresAtLeastOneSubscriber(int subscriptionCount, bool expected)
+    {
+        Assert.Equal(expected, XkcdJob.ShouldFetchFeed(subscriptionCount));
+    }
+}


### PR DESCRIPTION
## Summary
- skip the xkcd feed fetch when no channels are subscribed
- keep the global seen set empty so the first subscriber receives the intended latest-comic kick-off
- add regression coverage for the subscription gate

## Verification
- `dotnet build` — passed with 0 errors; reported the existing NU1903 warning for SQLitePCLRaw.lib.e_sqlite3 2.1.6
- `dotnet test --no-build` — passed: 159 tests, 0 failures, 0 skipped
- `git diff --check` — passed

## Risk
- Low: the change only avoids xkcd network/database work when there is no destination channel; subscribed behavior is unchanged.

Closes #15

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
