### PR TITLE
fix: ignore fragments in RSS feed URLs

### DIFF
--- a/Modules/SubscriptionsModule.cs
+++ b/Modules/SubscriptionsModule.cs
@@ -306,10 +306,13 @@ public class SubscriptionsModule : ModuleBase<SocketCommandContextExtended>
             return;
         }
 
-        string normalized = Uri.TryCreate(feedUrl, UriKind.Absolute, out Uri? uri) ? uri.ToString() : feedUrl;
+        string fragmentlessFeedUrl = SubscriptionInputParser.RemoveRssFragment(feedUrl);
+        string normalized = Uri.TryCreate(fragmentlessFeedUrl, UriKind.Absolute, out Uri? uri) ? uri.ToString() : fragmentlessFeedUrl;
+        string legacyFeedPattern = EscapeLikePattern(normalized) + "#%";
 
         RssSubscription? existing = await db.RssSubscriptions
-            .FirstOrDefaultAsync(s => s.ChannelDiscordId == target.Id && (s.FeedUrl == normalized || s.FeedUrl == feedUrl));
+            .FirstOrDefaultAsync(s => s.ChannelDiscordId == target.Id &&
+                (s.FeedUrl == normalized || EF.Functions.Like(s.FeedUrl, legacyFeedPattern, "\\")));
         if (existing == null)
         {
             await ReplyAsync($"That feed isn't being posted in <#{target.Id}>.");
@@ -723,7 +726,8 @@ public class SubscriptionsModule : ModuleBase<SocketCommandContextExtended>
         ITextChannel target,
         Webhook webhook)
     {
-        if (!Uri.TryCreate(source.Url, UriKind.Absolute, out Uri? uri) ||
+        string fragmentlessFeedUrl = SubscriptionInputParser.RemoveRssFragment(source.Url);
+        if (!Uri.TryCreate(fragmentlessFeedUrl, UriKind.Absolute, out Uri? uri) ||
             (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
             return BulkSubscribeResult.Failed(source.Url, "URL must start with http:// or https://.");
 
@@ -732,8 +736,10 @@ public class SubscriptionsModule : ModuleBase<SocketCommandContextExtended>
         if (feedTitle == null && entries.Count == 0)
             return BulkSubscribeResult.Failed(source.Url, "Feed could not be read.");
 
+        string legacyFeedPattern = EscapeLikePattern(feedUrl) + "#%";
         bool exists = await db.RssSubscriptions
-            .AnyAsync(subscription => subscription.ChannelDiscordId == target.Id && subscription.FeedUrl == feedUrl);
+            .AnyAsync(subscription => subscription.ChannelDiscordId == target.Id &&
+                (subscription.FeedUrl == feedUrl || EF.Functions.Like(subscription.FeedUrl, legacyFeedPattern, "\\")));
         if (exists)
             return BulkSubscribeResult.Already(source.Url, feedTitle ?? uri.Host);
 
@@ -940,6 +946,11 @@ public class SubscriptionsModule : ModuleBase<SocketCommandContextExtended>
 
         return input.ToLowerInvariant();
     }
+
+    internal static string EscapeLikePattern(string value) => value
+        .Replace("\\", "\\\\", StringComparison.Ordinal)
+        .Replace("%", "\\%", StringComparison.Ordinal)
+        .Replace("_", "\\_", StringComparison.Ordinal);
 
     private async Task SeedSeenVideosBestEffortAsync(string youtubeChannelId, IReadOnlyList<YoutubeFeedService.VideoEntry> entries)
     {

--- a/Morpheus.Tests/SubscriptionInputParserTests.cs
+++ b/Morpheus.Tests/SubscriptionInputParserTests.cs
@@ -86,4 +86,35 @@ public class SubscriptionInputParserTests
             ["https://example.com/Feed.xml", "https://example.com/feed.xml"],
             parsed.Select(source => source.Url));
     }
+
+    [Theory]
+    [InlineData("https://example.com/feed.xml#news https://example.com/feed.xml#releases")]
+    [InlineData("https://example.com/feed.xml#news\nhttps://example.com/feed.xml#releases")]
+    public void ParseRssSources_IgnoresFragmentsWhenDeduplicating(string input)
+    {
+        SubscriptionInputParser.RssSource source = Assert.Single(SubscriptionInputParser.ParseRssSources(input));
+
+        Assert.Equal("https://example.com/feed.xml", source.Url);
+    }
+
+    [Fact]
+    public void ParseRssSources_PreservesQueryWhenRemovingFragments()
+    {
+        IReadOnlyList<SubscriptionInputParser.RssSource> parsed = SubscriptionInputParser.ParseRssSources(
+            "https://example.com/feed.xml?category=news#top\nhttps://example.com/feed.xml?category=releases#top");
+
+        Assert.Equal(
+            ["https://example.com/feed.xml?category=news", "https://example.com/feed.xml?category=releases"],
+            parsed.Select(source => source.Url));
+    }
+
+    [Fact]
+    public void ParseRssSources_RemovesFragmentFromSingleFeedWithDisplayName()
+    {
+        SubscriptionInputParser.RssSource source = Assert.Single(
+            SubscriptionInputParser.ParseRssSources("https://example.com/feed.xml#news Example feed"));
+
+        Assert.Equal("https://example.com/feed.xml", source.Url);
+        Assert.Equal("Example feed", source.DisplayName);
+    }
 }

--- a/Morpheus.Tests/SubscriptionsModuleTests.cs
+++ b/Morpheus.Tests/SubscriptionsModuleTests.cs
@@ -11,4 +11,12 @@ public class SubscriptionsModuleTests
 
         Assert.Equal("streamer", login);
     }
+
+    [Fact]
+    public void EscapeLikePattern_EscapesWildcardsAndEscapeCharacters()
+    {
+        string escaped = SubscriptionsModule.EscapeLikePattern(@"https://example.com/feed?q=a%20_b\c");
+
+        Assert.Equal(@"https://example.com/feed?q=a\%20\_b\\c", escaped);
+    }
 }

--- a/Utilities/SubscriptionInputParser.cs
+++ b/Utilities/SubscriptionInputParser.cs
@@ -11,8 +11,7 @@ internal static partial class SubscriptionInputParser
         string Host,
         int Port,
         string UserInfo,
-        string PathAndQuery,
-        string Fragment);
+        string PathAndQuery);
 
     public static SourceList ParseSources(string input)
     {
@@ -46,7 +45,7 @@ internal static partial class SubscriptionInputParser
             if (urls.Length > 1)
                 return urls
                     .GroupBy(GetRssUrlKey)
-                    .Select(group => new RssSource(group.First(), null))
+                    .Select(group => new RssSource(RemoveRssFragment(group.First()), null))
                     .ToArray();
         }
 
@@ -73,7 +72,11 @@ internal static partial class SubscriptionInputParser
 
         return sources
             .GroupBy(source => GetRssUrlKey(source.Url))
-            .Select(group => group.First())
+            .Select(group =>
+            {
+                RssSource source = group.First();
+                return source with { Url = RemoveRssFragment(source.Url) };
+            })
             .ToArray();
     }
 
@@ -85,8 +88,13 @@ internal static partial class SubscriptionInputParser
             uri.IdnHost.ToLowerInvariant(),
             uri.Port,
             uri.UserInfo,
-            uri.PathAndQuery,
-            uri.Fragment);
+            uri.PathAndQuery);
+    }
+
+    internal static string RemoveRssFragment(string value)
+    {
+        int fragmentIndex = value.IndexOf('#');
+        return fragmentIndex >= 0 ? value[..fragmentIndex] : value;
     }
 
     private static IEnumerable<string> SplitTokens(string input) => input


### PR DESCRIPTION
## Summary
- treat URL fragments as irrelevant when deduplicating and storing RSS/Atom feed URLs
- preserve case-sensitive paths and distinct query strings
- recognize legacy fragment-bearing subscriptions without treating SQL wildcard characters as patterns

## Verification
- `dotnet build` — passed (0 errors; 2 existing NU1903 warnings for SQLitePCLRaw.lib.e_sqlite3 2.1.6)
- `dotnet test --no-build` — passed (170 tests)
- `git diff --check` — passed

## Risk
- Low: the change is limited to RSS URL identity handling and includes focused regression tests for fragment, query, path-case, and SQL pattern escaping behavior.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
