### PR TITLE
fix: retry failed RSS notifications

### DIFF
--- a/Jobs/RssFeedJob.cs
+++ b/Jobs/RssFeedJob.cs
@@ -48,7 +48,8 @@ public class RssFeedJob(DB db, RssFeedService rssFeed, DiscordWebhookService dis
             if (initialSeed)
             {
                 RssFeedService.FeedEntry latest = entries.OrderByDescending(e => e.Published).First();
-                await DispatchAsync(latest, subs);
+                if (!await DispatchAsync(latest, subs, SendAsync))
+                    continue;
 
                 foreach (RssFeedService.FeedEntry entry in entries)
                 {
@@ -64,7 +65,8 @@ public class RssFeedJob(DB db, RssFeedService rssFeed, DiscordWebhookService dis
                 if (seen.Contains(entry.EntryId))
                     continue;
 
-                await DispatchAsync(entry, subs);
+                if (!await DispatchAsync(entry, subs, SendAsync))
+                    continue;
 
                 db.RssSeenEntries.Add(new RssSeenEntry { FeedUrl = feedUrl, EntryId = entry.EntryId, SeenAt = DateTime.UtcNow });
                 seen.Add(entry.EntryId);
@@ -76,20 +78,37 @@ public class RssFeedJob(DB db, RssFeedService rssFeed, DiscordWebhookService dis
             await db.SaveChangesAsync();
     }
 
-    private async Task DispatchAsync(RssFeedService.FeedEntry entry, List<RssSubscription> subs)
+    internal static async Task<bool> DispatchAsync(
+        RssFeedService.FeedEntry entry,
+        IReadOnlyList<RssSubscription> subs,
+        Func<RssSubscription, string, Task<bool>> sendAsync)
     {
         string content = !string.IsNullOrWhiteSpace(entry.Link) ? entry.Link : entry.Title;
         if (string.IsNullOrWhiteSpace(content))
-            return;
+            return true;
 
+        bool allSucceeded = true;
         foreach (RssSubscription sub in subs)
         {
-            if (sub.Webhook == null)
-                continue;
-
-            bool ok = await discordWebhook.SendAsync(sub.Webhook.WebhookId, sub.Webhook.Token, content, sub.DisplayName, sub.AvatarUrl);
-            if (!ok)
-                logsService.Log($"RssFeedJob: failed to post entry from {sub.FeedUrl} to channel {sub.ChannelDiscordId}", LogSeverity.Warning);
+            if (!await sendAsync(sub, content))
+                allSucceeded = false;
         }
+
+        return allSucceeded;
+    }
+
+    private async Task<bool> SendAsync(RssSubscription sub, string content)
+    {
+        if (sub.Webhook == null)
+        {
+            logsService.Log($"RssFeedJob: no webhook available for {sub.FeedUrl} in channel {sub.ChannelDiscordId}", LogSeverity.Warning);
+            return false;
+        }
+
+        bool ok = await discordWebhook.SendAsync(sub.Webhook.WebhookId, sub.Webhook.Token, content, sub.DisplayName, sub.AvatarUrl);
+        if (!ok)
+            logsService.Log($"RssFeedJob: failed to post entry from {sub.FeedUrl} to channel {sub.ChannelDiscordId}", LogSeverity.Warning);
+
+        return ok;
     }
 }

--- a/Morpheus.Tests/RssFeedJobTests.cs
+++ b/Morpheus.Tests/RssFeedJobTests.cs
@@ -1,0 +1,76 @@
+using Morpheus.Database.Models;
+using Morpheus.Jobs;
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class RssFeedJobTests
+{
+    [Fact]
+    public async Task DispatchAsync_WhenOneDeliveryFails_ReportsFailureAndAttemptsEverySubscriber()
+    {
+        RssFeedService.FeedEntry entry = new("entry-1", "Entry", "https://example.com/entry-1", DateTime.UtcNow);
+        List<RssSubscription> subscriptions =
+        [
+            new() { ChannelDiscordId = 1 },
+            new() { ChannelDiscordId = 2 }
+        ];
+        List<ulong> attemptedChannels = [];
+
+        bool succeeded = await RssFeedJob.DispatchAsync(
+            entry,
+            subscriptions,
+            (subscription, _) =>
+            {
+                attemptedChannels.Add(subscription.ChannelDiscordId);
+                return Task.FromResult(subscription.ChannelDiscordId != 1);
+            });
+
+        Assert.False(succeeded);
+        Assert.Equal([1UL, 2UL], attemptedChannels);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_RetriesFailedDeliveryUntilEverySubscriberSucceeds()
+    {
+        RssFeedService.FeedEntry entry = new("entry-1", "Entry", "https://example.com/entry-1", DateTime.UtcNow);
+        List<RssSubscription> subscriptions =
+        [
+            new() { ChannelDiscordId = 1 },
+            new() { ChannelDiscordId = 2 }
+        ];
+        int attempts = 0;
+
+        Task<bool> SendAsync(RssSubscription _, string __)
+        {
+            attempts++;
+            return Task.FromResult(attempts > subscriptions.Count);
+        }
+
+        bool firstSucceeded = await RssFeedJob.DispatchAsync(entry, subscriptions, SendAsync);
+        bool secondSucceeded = await RssFeedJob.DispatchAsync(entry, subscriptions, SendAsync);
+
+        Assert.False(firstSucceeded);
+        Assert.True(secondSucceeded);
+        Assert.Equal(4, attempts);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenEntryHasNoContent_TreatsItAsHandledWithoutSending()
+    {
+        RssFeedService.FeedEntry entry = new("entry-1", string.Empty, string.Empty, DateTime.UtcNow);
+        bool sent = false;
+
+        bool succeeded = await RssFeedJob.DispatchAsync(
+            entry,
+            [new RssSubscription()],
+            (_, _) =>
+            {
+                sent = true;
+                return Task.FromResult(true);
+            });
+
+        Assert.True(succeeded);
+        Assert.False(sent);
+    }
+}


### PR DESCRIPTION
## Summary
- record RSS/Atom entries as seen only after every subscribed webhook delivery succeeds
- leave failed entries eligible for retry on the next poll, including during initial feed seeding
- add regression coverage for partial failure, retry, successful delivery, and contentless entries

## Verification
- `dotnet test --no-restore` — passed: 168 tests, 0 failures (with the existing NU1903 SQLitePCLRaw vulnerability warning)
- `dotnet build --no-restore` — passed: 0 errors (with the same existing NU1903 warning)
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Medium: seen state is global per feed, so a partial delivery failure retries the entry for every subscriber and can briefly duplicate a successful delivery; this avoids permanently losing the notification for the failed subscriber without adding a schema migration.

Closes #19

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
