### PR TITLE
fix: support maximum random number bound

### DIFF
--- a/Modules/MiscModule.cs
+++ b/Modules/MiscModule.cs
@@ -241,12 +241,16 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
     [RateLimit(3, 10)]
     public async Task RandomNumber(int min, int max)
     {
-        if (min >= max)
+        int number = GenerateRandomNumber(min, max);
+        await ReplyAsync(number.ToString());
+    }
+
+    internal static int GenerateRandomNumber(int min, int max)
+    {
+        if (min > max)
             (min, max) = (max, min);
 
-        Random random = new();
-        int number = random.Next(min, max + 1);
-        await ReplyAsync(number.ToString());
+        return (int)Random.Shared.NextInt64(min, (long)max + 1);
     }
 
     [Name("8 Ball")]

--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -12,4 +12,12 @@ public class MiscModuleTests
     {
         Assert.Equal(expected, MiscModule.NormalizeRockPaperScissorsChoice(choice));
     }
+
+    [Fact]
+    public void GenerateRandomNumber_SupportsIntMaxValueAsInclusiveUpperBound()
+    {
+        int result = MiscModule.GenerateRandomNumber(int.MaxValue, int.MaxValue);
+
+        Assert.Equal(int.MaxValue, result);
+    }
 }


### PR DESCRIPTION
## Summary
- avoid integer overflow when `randomnumber` uses `int.MaxValue` as its inclusive upper bound
- preserve equal and reversed range handling with a widened exclusive bound
- add a regression test for the maximum integer boundary

## Verification
- `dotnet build` — passed with the existing NU1903 SQLite package warning
- `dotnet test` — passed, 166 tests
- `git diff --check` — passed

## Risk
- Low: the change is isolated to random integer range generation and preserves the command's inclusive bounds.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
