### PR TITLE
fix: handle react commands without replies

### DIFF
--- a/Modules/EmojisModule.cs
+++ b/Modules/EmojisModule.cs
@@ -98,8 +98,8 @@ public class EmojisModule : ModuleBase<SocketCommandContextExtended>
         }
 
         // Get the message the user replied to
-
-        if (await Context.Channel.GetMessageAsync(Context.Message.ReferencedMessage.Id) is not IUserMessage message)
+        if (!TryGetReferencedMessageId(Context.Message.ReferencedMessage?.Id, out ulong referencedMessageId) ||
+            await Context.Channel.GetMessageAsync(referencedMessageId) is not IUserMessage message)
         {
             await ReplyAsync("You need to reply to a message to react to it.");
             return;
@@ -116,6 +116,12 @@ public class EmojisModule : ModuleBase<SocketCommandContextExtended>
         {
             logsService.Log($"Failed to delete user message after react: {ex}", LogSeverity.Warning);
         }
+    }
+
+    internal static bool TryGetReferencedMessageId(ulong? referencedMessageId, out ulong messageId)
+    {
+        messageId = referencedMessageId.GetValueOrDefault();
+        return referencedMessageId.HasValue;
     }
 
     [Name("List Emojis")]

--- a/Morpheus.Tests/EmojisModuleTests.cs
+++ b/Morpheus.Tests/EmojisModuleTests.cs
@@ -1,0 +1,24 @@
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class EmojisModuleTests
+{
+    [Fact]
+    public void TryGetReferencedMessageId_ReturnsFalseWhenReferenceIsMissing()
+    {
+        bool found = EmojisModule.TryGetReferencedMessageId(null, out ulong messageId);
+
+        Assert.False(found);
+        Assert.Equal(0UL, messageId);
+    }
+
+    [Fact]
+    public void TryGetReferencedMessageId_ReturnsReferenceIdWhenPresent()
+    {
+        bool found = EmojisModule.TryGetReferencedMessageId(42UL, out ulong messageId);
+
+        Assert.True(found);
+        Assert.Equal(42UL, messageId);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid dereferencing a missing message reference in the `react` command
- return the existing reply-required guidance when the command is not sent as a reply
- cover missing and present reference IDs with focused regression tests

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~EmojisModuleTests --nologo` — passed: 2/2
- `dotnet build --nologo` — passed: 0 errors (existing NU1903 package warning)
- `dotnet test --nologo` — passed: 167/167
- `python3 tools/generate_commands_md.py` — completed; command metadata was unchanged, and platform-only path separator churn was excluded
- `git diff --check` — passed

## Risk
- Low: the change only guards the missing-reference path and preserves the existing response for unavailable target messages.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
