### PR TITLE
fix: roll annual timeuntil events forward

### DIFF
--- a/Modules/MiscModule.cs
+++ b/Modules/MiscModule.cs
@@ -97,17 +97,17 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
                 break;
             case "christmas":
             case "xmas":
-                eventDate = new DateTime(now.Year, 12, 25);
+                eventDate = GetNextAnnualEventDate(now, 12, 25);
                 break;
             case "halloween":
             case "hw":
-                eventDate = new DateTime(now.Year, 10, 31);
+                eventDate = GetNextAnnualEventDate(now, 10, 31);
                 break;
             case "cc day":
             case "ccbday":
             case "cc bday":
             case "cc birthday":
-                eventDate = new DateTime(now.Year, 9, 2);
+                eventDate = GetNextAnnualEventDate(now, 9, 2);
                 break;
             default:
                 await ReplyAsync("Invalid event name.\nValid events are: `new year`, `xmas`, `halloween`, `cc bday`");
@@ -116,6 +116,12 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
 
         string timeUntil = now.GetAccurateTimeSpan(eventDate);
         await ReplyAsync($"Time until {eventName}: {timeUntil}");
+    }
+
+    internal static DateTime GetNextAnnualEventDate(DateTime now, int month, int day)
+    {
+        DateTime eventDate = new(now.Year, month, day, 0, 0, 0, now.Kind);
+        return eventDate < now ? eventDate.AddYears(1) : eventDate;
     }
 
     [Name("Coin Flip")]

--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -5,6 +5,28 @@ namespace Morpheus.Tests;
 public class MiscModuleTests
 {
     [Theory]
+    [InlineData(2026, 12, 24, 12, 12, 25, 2026)]
+    [InlineData(2026, 12, 25, 0, 12, 25, 2026)]
+    [InlineData(2026, 12, 25, 12, 12, 25, 2027)]
+    [InlineData(2026, 11, 1, 12, 10, 31, 2027)]
+    [InlineData(2026, 9, 3, 12, 9, 2, 2027)]
+    public void GetNextAnnualEventDate_ReturnsNextOccurrence(
+        int currentYear,
+        int currentMonth,
+        int currentDay,
+        int currentHour,
+        int eventMonth,
+        int eventDay,
+        int expectedYear)
+    {
+        DateTime now = new(currentYear, currentMonth, currentDay, currentHour, 0, 0, DateTimeKind.Utc);
+
+        DateTime result = MiscModule.GetNextAnnualEventDate(now, eventMonth, eventDay);
+
+        Assert.Equal(new DateTime(expectedYear, eventMonth, eventDay, 0, 0, 0, DateTimeKind.Utc), result);
+    }
+
+    [Theory]
     [InlineData("ROCK", "rock")]
     [InlineData("PaPeR", "paper")]
     [InlineData("ScIsSoRs", "scissors")]


### PR DESCRIPTION
## Summary
- roll Christmas, Halloween, and CC birthday dates into the following year once their current-year occurrence has passed
- add regression coverage for dates before, exactly at, and after annual event boundaries

## Verification
- `dotnet build` — passed (2 existing NU1903 package vulnerability warnings)
- `dotnet test` — passed (170 tests)
- `git diff --check upstream/develop...HEAD` — passed
- command documentation generator comparison — passed after normalizing existing Windows path separators; command metadata is unchanged

## Risk
- Low: the change is limited to annual date selection for the `timeuntil` command and preserves the existing event times at midnight UTC.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
