### PR TITLE
fix: handle missing owner configuration

### DIFF
--- a/Modules/AdministratorModule.cs
+++ b/Modules/AdministratorModule.cs
@@ -19,8 +19,7 @@ public class AdministratorModule(DiscordSocketClient client, DB dbContext) : Mod
     public async Task DumpLogsAsync(int page = 1)
     {
         // Check OWNER_ID environment variable
-        string? ownerEnv = Env.Variables["OWNER_ID"];
-        if (string.IsNullOrWhiteSpace(ownerEnv) || !ulong.TryParse(ownerEnv, out var ownerId))
+        if (!TryParseOwnerId(Env.Variables.GetValueOrDefault("OWNER_ID"), out var ownerId))
         {
             await ReplyAsync("Owner not configured.");
             return;
@@ -88,8 +87,7 @@ public class AdministratorModule(DiscordSocketClient client, DB dbContext) : Mod
     public async Task GuildCountAsync()
     {
         // Check OWNER_ID environment variable
-        string? ownerEnv = Env.Variables["OWNER_ID"];
-        if (string.IsNullOrWhiteSpace(ownerEnv) || !ulong.TryParse(ownerEnv, out var ownerId))
+        if (!TryParseOwnerId(Env.Variables.GetValueOrDefault("OWNER_ID"), out var ownerId))
         {
             await ReplyAsync("Owner not configured.");
             return;
@@ -114,8 +112,7 @@ public class AdministratorModule(DiscordSocketClient client, DB dbContext) : Mod
     public async Task SendToChannelAsync(ulong channelId, [Remainder] string text)
     {
         // Check OWNER_ID environment variable
-        string? ownerEnv = Env.Variables["OWNER_ID"];
-        if (string.IsNullOrWhiteSpace(ownerEnv) || !ulong.TryParse(ownerEnv, out var ownerId))
+        if (!TryParseOwnerId(Env.Variables.GetValueOrDefault("OWNER_ID"), out var ownerId))
         {
             await ReplyAsync("Owner not configured.");
             return;
@@ -163,5 +160,11 @@ public class AdministratorModule(DiscordSocketClient client, DB dbContext) : Mod
         {
             await ReplyAsync($"Failed to send message: {ex.Message}");
         }
+    }
+
+    internal static bool TryParseOwnerId(string? value, out ulong ownerId)
+    {
+        ownerId = 0;
+        return !string.IsNullOrWhiteSpace(value) && ulong.TryParse(value, out ownerId);
     }
 }

--- a/Morpheus.Tests/AdministratorModuleTests.cs
+++ b/Morpheus.Tests/AdministratorModuleTests.cs
@@ -1,0 +1,23 @@
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class AdministratorModuleTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-user-id")]
+    public void TryParseOwnerId_RejectsMissingOrInvalidValues(string? value)
+    {
+        Assert.False(AdministratorModule.TryParseOwnerId(value, out _));
+    }
+
+    [Fact]
+    public void TryParseOwnerId_AcceptsValidDiscordUserId()
+    {
+        Assert.True(AdministratorModule.TryParseOwnerId("123456789012345678", out ulong ownerId));
+        Assert.Equal(123456789012345678UL, ownerId);
+    }
+}


### PR DESCRIPTION
## Summary
- safely read the optional `OWNER_ID` setting for owner-only administrator commands
- return the existing "Owner not configured." response instead of throwing when the setting is absent
- add coverage for missing, invalid, and valid owner IDs

## Verification
- `dotnet build` — passed (with the pre-existing NU1903 SQLitePCLRaw vulnerability warning)
- `dotnet test` — passed, 170 tests
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change is limited to owner-ID validation in three hidden administrator commands and preserves valid-ID behavior.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
