### PR TITLE
fix: retry failed YouTube notifications

### DIFF
--- a/Jobs/YoutubeRssJob.cs
+++ b/Jobs/YoutubeRssJob.cs
@@ -71,7 +71,8 @@ public class YoutubeRssJob(DB db, YoutubeFeedService youtubeFeed, DiscordWebhook
             if (initialSeed)
             {
                 YoutubeFeedService.VideoEntry latest = entries.OrderByDescending(e => e.Published).First();
-                await DispatchAsync(latest, subs, username, avatar);
+                if (!await DispatchAsync(subs, sub => SendAsync(sub, latest, username, avatar)))
+                    continue;
 
                 foreach (YoutubeFeedService.VideoEntry entry in entries)
                 {
@@ -87,7 +88,8 @@ public class YoutubeRssJob(DB db, YoutubeFeedService youtubeFeed, DiscordWebhook
                 if (seen.Contains(entry.VideoId))
                     continue;
 
-                await DispatchAsync(entry, subs, username, avatar);
+                if (!await DispatchAsync(subs, sub => SendAsync(sub, entry, username, avatar)))
+                    continue;
 
                 db.YoutubeSeenVideos.Add(new YoutubeSeenVideo { YoutubeChannelId = youtubeChannelId, VideoId = entry.VideoId, SeenAt = DateTime.UtcNow });
                 seen.Add(entry.VideoId);
@@ -99,16 +101,36 @@ public class YoutubeRssJob(DB db, YoutubeFeedService youtubeFeed, DiscordWebhook
             await db.SaveChangesAsync();
     }
 
-    private async Task DispatchAsync(YoutubeFeedService.VideoEntry entry, List<YoutubeSubscription> subs, string username, string? avatar)
+    internal static async Task<bool> DispatchAsync(
+        IReadOnlyList<YoutubeSubscription> subs,
+        Func<YoutubeSubscription, Task<bool>> sendAsync)
     {
+        bool allSucceeded = true;
         foreach (YoutubeSubscription sub in subs)
         {
-            if (sub.Webhook == null)
-                continue;
-
-            bool ok = await discordWebhook.SendAsync(sub.Webhook.WebhookId, sub.Webhook.Token, entry.Link, username, avatar);
-            if (!ok)
-                logsService.Log($"YoutubeRssJob: failed to post {entry.VideoId} to channel {sub.ChannelDiscordId}", LogSeverity.Warning);
+            if (!await sendAsync(sub))
+                allSucceeded = false;
         }
+
+        return allSucceeded;
+    }
+
+    private async Task<bool> SendAsync(
+        YoutubeSubscription sub,
+        YoutubeFeedService.VideoEntry entry,
+        string username,
+        string? avatar)
+    {
+        if (sub.Webhook == null)
+        {
+            logsService.Log($"YoutubeRssJob: no webhook available for {sub.YoutubeChannelId} in channel {sub.ChannelDiscordId}", LogSeverity.Warning);
+            return false;
+        }
+
+        bool ok = await discordWebhook.SendAsync(sub.Webhook.WebhookId, sub.Webhook.Token, entry.Link, username, avatar);
+        if (!ok)
+            logsService.Log($"YoutubeRssJob: failed to post {entry.VideoId} to channel {sub.ChannelDiscordId}", LogSeverity.Warning);
+
+        return ok;
     }
 }

--- a/Morpheus.Tests/YoutubeRssJobTests.cs
+++ b/Morpheus.Tests/YoutubeRssJobTests.cs
@@ -1,0 +1,53 @@
+using Morpheus.Database.Models;
+using Morpheus.Jobs;
+
+namespace Morpheus.Tests;
+
+public class YoutubeRssJobTests
+{
+    [Fact]
+    public async Task DispatchAsync_WhenOneDeliveryFails_ReportsFailureAndAttemptsEverySubscriber()
+    {
+        List<YoutubeSubscription> subscriptions =
+        [
+            new() { ChannelDiscordId = 1 },
+            new() { ChannelDiscordId = 2 }
+        ];
+        List<ulong> attemptedChannels = [];
+
+        bool succeeded = await YoutubeRssJob.DispatchAsync(
+            subscriptions,
+            subscription =>
+            {
+                attemptedChannels.Add(subscription.ChannelDiscordId);
+                return Task.FromResult(subscription.ChannelDiscordId != 1);
+            });
+
+        Assert.False(succeeded);
+        Assert.Equal([1UL, 2UL], attemptedChannels);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_RetriesFailedDeliveryUntilEverySubscriberSucceeds()
+    {
+        List<YoutubeSubscription> subscriptions =
+        [
+            new() { ChannelDiscordId = 1 },
+            new() { ChannelDiscordId = 2 }
+        ];
+        int attempts = 0;
+
+        Task<bool> SendAsync(YoutubeSubscription _)
+        {
+            attempts++;
+            return Task.FromResult(attempts > subscriptions.Count);
+        }
+
+        bool firstSucceeded = await YoutubeRssJob.DispatchAsync(subscriptions, SendAsync);
+        bool secondSucceeded = await YoutubeRssJob.DispatchAsync(subscriptions, SendAsync);
+
+        Assert.False(firstSucceeded);
+        Assert.True(secondSucceeded);
+        Assert.Equal(4, attempts);
+    }
+}


### PR DESCRIPTION
## Summary
- retry YouTube notifications when any subscriber webhook delivery fails
- avoid recording initial or subsequent videos as seen until every subscriber delivery succeeds
- log missing webhooks and add regression tests for partial failure and retry behavior

## Verification
- `dotnet build` — passed (with the existing NU1903 advisory warning for SQLitePCLRaw.lib.e_sqlite3 2.1.6)
- `dotnet test` — passed: 188 tests, 0 failed, 0 skipped (same existing NU1903 warning)
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change is limited to YouTube webhook failure handling and mirrors the existing RSS retry behavior. Successful subscribers may receive a duplicate when a later run retries a video after another subscriber failed.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
