### PR TITLE
fix: handle pin commands without replies

### DIFF
--- a/Modules/UtilityModule.cs
+++ b/Modules/UtilityModule.cs
@@ -44,7 +44,8 @@ public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtend
         }
 
         // Get the message the user replied to
-        if (await Context.Channel.GetMessageAsync(Context.Message.ReferencedMessage.Id) is not IUserMessage message)
+        if (!TryGetReferencedMessageId(Context.Message.ReferencedMessage?.Id, out ulong referencedMessageId) ||
+            await Context.Channel.GetMessageAsync(referencedMessageId) is not IUserMessage message)
         {
             await ReplyAsync("Couldn't find the message you want to pin.");
             return;
@@ -76,6 +77,12 @@ public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtend
         await ReplyAsync("Message pinned successfully.");
 
         return;
+    }
+
+    internal static bool TryGetReferencedMessageId(ulong? referencedMessageId, out ulong messageId)
+    {
+        messageId = referencedMessageId.GetValueOrDefault();
+        return referencedMessageId.HasValue;
     }
 
     [Name("Reminder")]

--- a/Morpheus.Tests/UtilityModuleTests.cs
+++ b/Morpheus.Tests/UtilityModuleTests.cs
@@ -1,0 +1,24 @@
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class UtilityModuleTests
+{
+    [Fact]
+    public void TryGetReferencedMessageId_ReturnsFalseWhenReferenceIsMissing()
+    {
+        bool found = UtilityModule.TryGetReferencedMessageId(null, out ulong messageId);
+
+        Assert.False(found);
+        Assert.Equal(0UL, messageId);
+    }
+
+    [Fact]
+    public void TryGetReferencedMessageId_ReturnsReferenceIdWhenPresent()
+    {
+        bool found = UtilityModule.TryGetReferencedMessageId(42UL, out ulong messageId);
+
+        Assert.True(found);
+        Assert.Equal(42UL, messageId);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid dereferencing a missing message reference when `pin` is invoked without replying to a message
- preserve the existing not-found response and cover missing/present reference IDs with focused regression tests

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~UtilityModuleTests --nologo` — passed: 2/2
- `dotnet build --nologo` — passed: 0 errors (existing NU1903 package warning)
- `dotnet test --nologo` — passed: 190/190
- `python3 tools/generate_commands_md.py` — completed; command metadata was unchanged, so generated line-ending churn was excluded
- `git diff upstream/develop...HEAD --check` — passed

## Risk
- Low: the change only guards the missing-reference path and keeps existing behavior for valid or unavailable referenced messages.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
