### PR TITLE
fix: retry failed xkcd deliveries

### DIFF
--- a/Database/DB.cs
+++ b/Database/DB.cs
@@ -87,6 +87,7 @@ public class DB(DbContextOptions<DB> options) : Microsoft.EntityFrameworkCore.Db
         // xkcd: one subscription per channel, global "seen" set keyed by comic link
         modelBuilder.Entity<XkcdSubscription>().HasIndex(s => s.ChannelDiscordId).IsUnique();
         modelBuilder.Entity<XkcdSeen>().HasIndex(s => s.Link).IsUnique();
+        modelBuilder.Entity<XkcdDeliveryRetry>().HasIndex(r => r.Link).IsUnique();
         modelBuilder.Entity<XkcdSubscription>()
             .HasOne(s => s.Webhook)
             .WithMany()
@@ -146,6 +147,7 @@ public class DB(DbContextOptions<DB> options) : Microsoft.EntityFrameworkCore.Db
     public DbSet<Webhook> Webhooks { get; set; }
     public DbSet<XkcdSubscription> XkcdSubscriptions { get; set; }
     public DbSet<XkcdSeen> XkcdSeen { get; set; }
+    public DbSet<XkcdDeliveryRetry> XkcdDeliveryRetries { get; set; }
     public DbSet<YoutubeSubscription> YoutubeSubscriptions { get; set; }
     public DbSet<YoutubeSeenVideo> YoutubeSeenVideos { get; set; }
     public DbSet<RssSubscription> RssSubscriptions { get; set; }

--- a/Database/Models/XkcdDeliveryRetry.cs
+++ b/Database/Models/XkcdDeliveryRetry.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Morpheus.Database.Models;
+
+/// <summary>
+/// Tracks consecutive hourly delivery attempts for an xkcd comic so a broken webhook cannot
+/// cause successful subscribers to receive the same comic indefinitely.
+/// </summary>
+public class XkcdDeliveryRetry
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    [Required]
+    public string Link { get; set; } = string.Empty;
+
+    public int AttemptCount { get; set; }
+
+    public DateTime LastAttemptAt { get; set; } = DateTime.UtcNow;
+}

--- a/Jobs/XkcdJob.cs
+++ b/Jobs/XkcdJob.cs
@@ -61,12 +61,14 @@ public class XkcdJob(DB db, DiscordWebhookService discordWebhook, LogsService lo
         // First run ever: seed everything as seen so we don't backfill the whole archive.
         if (!hasSeen)
         {
+            // Post only the most recent comic to existing subscribers as a kick-off.
+            XkcdItem latest = items[0];
+            if (!await DispatchAsync(latest.Link, subscriptions, SendAsync))
+                return;
+
             foreach (XkcdItem item in items)
                 db.XkcdSeen.Add(new XkcdSeen { Link = item.Link, SeenAt = DateTime.UtcNow });
 
-            // Post only the most recent comic to existing subscribers as a kick-off.
-            XkcdItem latest = items[0];
-            await DispatchAsync(latest, subscriptions);
             await db.SaveChangesAsync();
             return;
         }
@@ -85,21 +87,42 @@ public class XkcdJob(DB db, DiscordWebhookService discordWebhook, LogsService lo
 
         foreach (XkcdItem item in newItems)
         {
-            await DispatchAsync(item, subscriptions);
+            if (!await DispatchAsync(item.Link, subscriptions, SendAsync))
+                continue;
+
             db.XkcdSeen.Add(new XkcdSeen { Link = item.Link, SeenAt = DateTime.UtcNow });
         }
 
         await db.SaveChangesAsync();
     }
 
-    private async Task DispatchAsync(XkcdItem item, List<XkcdSubscription> subscriptions)
+    internal static async Task<bool> DispatchAsync(
+        string link,
+        IReadOnlyList<XkcdSubscription> subscriptions,
+        Func<XkcdSubscription, string, Task<bool>> sendAsync)
     {
+        bool allSucceeded = true;
         foreach (XkcdSubscription sub in subscriptions)
         {
-            if (sub.Webhook == null)
-                continue;
-
-            await discordWebhook.SendAsync(sub.Webhook.WebhookId, sub.Webhook.Token, item.Link, XkcdUsername, XkcdAvatarUrl);
+            if (!await sendAsync(sub, link))
+                allSucceeded = false;
         }
+
+        return allSucceeded;
+    }
+
+    private async Task<bool> SendAsync(XkcdSubscription sub, string link)
+    {
+        if (sub.Webhook == null)
+        {
+            logsService.Log($"XkcdJob: no webhook available in channel {sub.ChannelDiscordId}", LogSeverity.Warning);
+            return false;
+        }
+
+        bool ok = await discordWebhook.SendAsync(sub.Webhook.WebhookId, sub.Webhook.Token, link, XkcdUsername, XkcdAvatarUrl);
+        if (!ok)
+            logsService.Log($"XkcdJob: failed to post comic to channel {sub.ChannelDiscordId}", LogSeverity.Warning);
+
+        return ok;
     }
 }

--- a/Jobs/XkcdJob.cs
+++ b/Jobs/XkcdJob.cs
@@ -18,6 +18,7 @@ public class XkcdJob(DB db, DiscordWebhookService discordWebhook, LogsService lo
     private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
 
     private const string XkcdUsername = "xkcd";
+    internal const int MaxDeliveryAttempts = 24 * 7;
     // Public square avatar for the xkcd identity (data: URLs are rejected by Discord's avatar_url).
     private const string XkcdAvatarUrl = "https://pbs.twimg.com/profile_images/1488600831377252354/hEpPeSu0_400x400.jpg";
 
@@ -61,13 +62,31 @@ public class XkcdJob(DB db, DiscordWebhookService discordWebhook, LogsService lo
         // First run ever: seed everything as seen so we don't backfill the whole archive.
         if (!hasSeen)
         {
-            // Post only the most recent comic to existing subscribers as a kick-off.
-            XkcdItem latest = items[0];
-            if (!await DispatchAsync(latest.Link, subscriptions, SendAsync))
-                return;
+            // Post only the most recent comic to existing subscribers as a kick-off. If an
+            // earlier attempt is pending, keep retrying that same comic even if it has rotated
+            // out of the RSS feed.
+            string latestLink = await db.XkcdDeliveryRetries
+                .OrderBy(r => r.LastAttemptAt)
+                .Select(r => r.Link)
+                .FirstOrDefaultAsync() ?? items[0].Link;
+            bool delivered = await DispatchAsync(latestLink, subscriptions, SendAsync);
+            if (!delivered)
+            {
+                int attempts = await RecordFailedDeliveryAsync(db, latestLink, DateTime.UtcNow);
+                if (ShouldRetryDelivery(attempts))
+                    return;
+
+                logsService.Log(
+                    $"XkcdJob: giving up on {latestLink} after {attempts} hourly delivery attempts",
+                    LogSeverity.Warning);
+            }
+
+            await ClearDeliveryRetryAsync(latestLink);
 
             foreach (XkcdItem item in items)
                 db.XkcdSeen.Add(new XkcdSeen { Link = item.Link, SeenAt = DateTime.UtcNow });
+            if (items.All(item => item.Link != latestLink))
+                db.XkcdSeen.Add(new XkcdSeen { Link = latestLink, SeenAt = DateTime.UtcNow });
 
             await db.SaveChangesAsync();
             return;
@@ -80,17 +99,40 @@ public class XkcdJob(DB db, DiscordWebhookService discordWebhook, LogsService lo
                 .ToListAsync())
             .ToHashSet();
 
-        // RSS is newest-first; post new comics oldest-first so they read chronologically.
-        List<XkcdItem> newItems = items.Where(i => !seen.Contains(i.Link)).Reverse().ToList();
-        if (newItems.Count == 0)
+        // Retry pending comics first, including links that have rotated out of the RSS feed.
+        // RSS is newest-first; post other new comics oldest-first so they read chronologically.
+        List<string> pendingLinks = await db.XkcdDeliveryRetries
+            .OrderBy(r => r.LastAttemptAt)
+            .Select(r => r.Link)
+            .ToListAsync();
+        HashSet<string> pendingLinkSet = pendingLinks.ToHashSet();
+        List<string> deliveryLinks =
+        [
+            .. pendingLinks,
+            .. items
+                .Where(i => !seen.Contains(i.Link) && !pendingLinkSet.Contains(i.Link))
+                .Reverse()
+                .Select(i => i.Link)
+        ];
+        if (deliveryLinks.Count == 0)
             return;
 
-        foreach (XkcdItem item in newItems)
+        foreach (string link in deliveryLinks)
         {
-            if (!await DispatchAsync(item.Link, subscriptions, SendAsync))
-                continue;
+            bool delivered = await DispatchAsync(link, subscriptions, SendAsync);
+            if (!delivered)
+            {
+                int attempts = await RecordFailedDeliveryAsync(db, link, DateTime.UtcNow);
+                if (ShouldRetryDelivery(attempts))
+                    continue;
 
-            db.XkcdSeen.Add(new XkcdSeen { Link = item.Link, SeenAt = DateTime.UtcNow });
+                logsService.Log(
+                    $"XkcdJob: giving up on {link} after {attempts} hourly delivery attempts",
+                    LogSeverity.Warning);
+            }
+
+            await ClearDeliveryRetryAsync(link);
+            db.XkcdSeen.Add(new XkcdSeen { Link = link, SeenAt = DateTime.UtcNow });
         }
 
         await db.SaveChangesAsync();
@@ -109,6 +151,38 @@ public class XkcdJob(DB db, DiscordWebhookService discordWebhook, LogsService lo
         }
 
         return allSucceeded;
+    }
+
+    internal static bool ShouldRetryDelivery(int attemptCount) => attemptCount < MaxDeliveryAttempts;
+
+    internal static async Task<int> RecordFailedDeliveryAsync(DB db, string link, DateTime attemptedAt)
+    {
+        XkcdDeliveryRetry? retry = await db.XkcdDeliveryRetries.SingleOrDefaultAsync(r => r.Link == link);
+        if (retry == null)
+        {
+            retry = new XkcdDeliveryRetry
+            {
+                Link = link,
+                AttemptCount = 1,
+                LastAttemptAt = attemptedAt
+            };
+            db.XkcdDeliveryRetries.Add(retry);
+        }
+        else
+        {
+            retry.AttemptCount++;
+            retry.LastAttemptAt = attemptedAt;
+        }
+
+        await db.SaveChangesAsync();
+        return retry.AttemptCount;
+    }
+
+    private async Task ClearDeliveryRetryAsync(string link)
+    {
+        XkcdDeliveryRetry? retry = await db.XkcdDeliveryRetries.SingleOrDefaultAsync(r => r.Link == link);
+        if (retry != null)
+            db.XkcdDeliveryRetries.Remove(retry);
     }
 
     private async Task<bool> SendAsync(XkcdSubscription sub, string link)

--- a/Migrations/20260731071835_BoundXkcdDeliveryRetries.Designer.cs
+++ b/Migrations/20260731071835_BoundXkcdDeliveryRetries.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Morpheus.Database;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Morpheus.Migrations
 {
     [DbContext(typeof(DB))]
-    partial class DBModelSnapshot : ModelSnapshot
+    [Migration("20260731071835_BoundXkcdDeliveryRetries")]
+    partial class BoundXkcdDeliveryRetries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260731071835_BoundXkcdDeliveryRetries.cs
+++ b/Migrations/20260731071835_BoundXkcdDeliveryRetries.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Morpheus.Migrations
+{
+    /// <inheritdoc />
+    public partial class BoundXkcdDeliveryRetries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "XkcdDeliveryRetries",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Link = table.Column<string>(type: "text", nullable: false),
+                    AttemptCount = table.Column<int>(type: "integer", nullable: false),
+                    LastAttemptAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_XkcdDeliveryRetries", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_XkcdDeliveryRetries_Link",
+                table: "XkcdDeliveryRetries",
+                column: "Link",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "XkcdDeliveryRetries");
+        }
+    }
+}

--- a/Morpheus.Tests/XkcdJobTests.cs
+++ b/Morpheus.Tests/XkcdJobTests.cs
@@ -1,3 +1,4 @@
+using Morpheus.Database.Models;
 using Morpheus.Jobs;
 
 namespace Morpheus.Tests;
@@ -11,5 +12,28 @@ public class XkcdJobTests
     public void ShouldFetchFeed_RequiresAtLeastOneSubscriber(int subscriptionCount, bool expected)
     {
         Assert.Equal(expected, XkcdJob.ShouldFetchFeed(subscriptionCount));
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenOneDeliveryFails_ReportsFailureAndAttemptsEverySubscriber()
+    {
+        List<XkcdSubscription> subscriptions =
+        [
+            new() { ChannelDiscordId = 1 },
+            new() { ChannelDiscordId = 2 }
+        ];
+        List<ulong> attemptedChannels = [];
+
+        bool succeeded = await XkcdJob.DispatchAsync(
+            "https://xkcd.com/1/",
+            subscriptions,
+            (subscription, _) =>
+            {
+                attemptedChannels.Add(subscription.ChannelDiscordId);
+                return Task.FromResult(subscription.ChannelDiscordId != 1);
+            });
+
+        Assert.False(succeeded);
+        Assert.Equal([1UL, 2UL], attemptedChannels);
     }
 }

--- a/Morpheus.Tests/XkcdJobTests.cs
+++ b/Morpheus.Tests/XkcdJobTests.cs
@@ -1,3 +1,6 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
 using Morpheus.Database.Models;
 using Morpheus.Jobs;
 
@@ -35,5 +38,45 @@ public class XkcdJobTests
 
         Assert.False(succeeded);
         Assert.Equal([1UL, 2UL], attemptedChannels);
+    }
+
+    [Fact]
+    public async Task RecordFailedDeliveryAsync_PersistsOneWeekOfHourlyAttempts()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        const string link = "https://xkcd.com/1/";
+        DateTime startedAt = new(2026, 7, 31, 0, 0, 0, DateTimeKind.Utc);
+
+        for (int attempt = 1; attempt <= XkcdJob.MaxDeliveryAttempts; attempt++)
+        {
+            int recordedAttempts = await XkcdJob.RecordFailedDeliveryAsync(
+                db,
+                link,
+                startedAt.AddHours(attempt - 1));
+
+            Assert.Equal(attempt, recordedAttempts);
+        }
+
+        XkcdDeliveryRetry retry = await db.XkcdDeliveryRetries.SingleAsync();
+        Assert.Equal(168, retry.AttemptCount);
+        Assert.Equal(startedAt.AddHours(167), retry.LastAttemptAt);
+        Assert.False(XkcdJob.ShouldRetryDelivery(retry.AttemptCount));
+    }
+
+    [Theory]
+    [InlineData(1, true)]
+    [InlineData(167, true)]
+    [InlineData(168, false)]
+    [InlineData(169, false)]
+    public void ShouldRetryDelivery_StopsAfterOneWeek(int attemptCount, bool expected)
+    {
+        Assert.Equal(expected, XkcdJob.ShouldRetryDelivery(attemptCount));
     }
 }


### PR DESCRIPTION
## Summary
- retry xkcd comics when any subscribed webhook delivery fails instead of marking them seen immediately
- persist retry state across restarts and retry hourly for at most 168 attempts (one week)
- keep retrying pending comic links after they rotate out of the RSS feed
- mark a comic seen after success or after the retry limit, preventing indefinite duplicate delivery to healthy subscribers
- log missing webhooks, failed sends, and final abandonment
- add regression coverage for partial fan-out failures and the persisted one-week boundary

## Database
- added `XkcdDeliveryRetries` with a unique comic-link index
- generated `BoundXkcdDeliveryRetries` using Entity Framework tooling
- verified the generated migration SQL and confirmed there are no pending model changes

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter "FullyQualifiedName~XkcdJobTests"` — passed: 9 tests
- `dotnet build Morpheus.sln --no-restore` — passed with the existing NU1903 SQLite package advisory warning
- `dotnet test Morpheus.sln --no-build --no-restore` — 193 passed; 1 pre-existing CRLF/LF-sensitive leaderboard test failed identically on `develop`
- `dotnet ef migrations has-pending-model-changes` — no pending changes
- `git diff --check` — passed

## Risk
- Medium: a partial delivery failure can resend a comic to successful subscribers hourly, but retries are now bounded to one week. After 168 failed attempts, the comic is marked seen even if one or more subscribers never received it.

This was generated by an AI agent (vycdev2) and subsequently reviewed and updated. Please verify any changes before merging or applying.