### PR TITLE
fix: detect bare URLs after punctuation

### DIFF
--- a/Morpheus.Tests/UtilsTests.cs
+++ b/Morpheus.Tests/UtilsTests.cs
@@ -1,0 +1,28 @@
+using Morpheus.Utilities;
+
+namespace Morpheus.Tests;
+
+public class UtilsTests
+{
+    [Theory]
+    [InlineData("(example.com)")]
+    [InlineData("\"example.com\"")]
+    [InlineData("See:example.com")]
+    [InlineData("Visit example.com.")]
+    public void ContainsUrl_DetectsBareDomainsAfterPunctuation(string text)
+    {
+        Assert.True(Utils.ContainsUrl(text));
+    }
+
+    [Theory]
+    [InlineData("user@example.com")]
+    [InlineData("user+example.com@example.org")]
+    [InlineData("user%example.com@example.org")]
+    [InlineData("user+example.com+tag@example.org")]
+    [InlineData("user%example.com+tag@example.org")]
+    [InlineData("user+example.com/path@example.org")]
+    public void ContainsUrl_DoesNotTreatEmailAddressAsBareDomain(string text)
+    {
+        Assert.False(Utils.ContainsUrl(text));
+    }
+}

--- a/Utilities/Utils.cs
+++ b/Utilities/Utils.cs
@@ -9,7 +9,7 @@ public static class Utils
     // Precompiled regexes shared across calls
     private static readonly Regex _schemeRegex = new(@"\b(?:https?|ftp)://[\w\-\._~:/?#\[\]@!$&'()*+,;=%]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex _mdLinkRegex = new(@"\[[^\]]+\]\((?:https?://|ftp://|www\.)[^)\s]+\)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex _bareDomainRegex = new(@"(?<=\s|^)(?:www\.)?(?:[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}(?::\d{1,5})?(?:/[^\s]*)?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex _bareDomainRegex = new(@"(?<![a-z0-9.!#$%&'*+/=?^_`{|}~@-])(?:www\.)?(?:[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}(?::\d{1,5})?(?![a-z0-9.!#$%&'*+/=?^_`{|}~-]*@)(?:/[^\s]*)?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex _ipRegex = new(@"(?<=\s|^)(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(?::\d{1,5})?(?:/[^\s]*)?(?=\s|$)", RegexOptions.Compiled);
 
     public static string GetAssemblyVersion()


### PR DESCRIPTION
## Summary
- detect bare domain URLs when they follow common punctuation such as parentheses, quotes, or colons
- preserve email-address exclusions, including local parts that contain common punctuation
- add focused regression coverage for punctuated domains and email-like inputs

## Verification
- `dotnet build` — passed (with the existing SQLitePCLRaw vulnerability warning)
- `dotnet test --no-build` — passed: 198 tests
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~UtilsTests` — passed: 10 tests
- `git diff --check` — passed

## Risk
- Low: the change is isolated to the bare-domain URL heuristic and is covered by focused regression tests.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
