### PR TITLE
docs: correct reminder minimum duration

### DIFF
--- a/Modules/UtilityModule.cs
+++ b/Modules/UtilityModule.cs
@@ -79,7 +79,7 @@ public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtend
     }
 
     [Name("Reminder")]
-    [Summary("Sets a reminder using a duration specification (e.g. '5 days and 3 hours'). Minimum 5 seconds, maximum 100 years. Usage: reminder <duration> [@user] [text...]. Example: reminder 5 days and 3 hours @User Take a break. Reminders are executed once a minute.")]
+    [Summary("Sets a reminder using a duration specification (e.g. '5 days and 3 hours'). Minimum 1 minute, maximum 100 years. Usage: reminder <duration> [@user] [text...]. Example: reminder 5 days and 3 hours @User Take a break. Reminders are executed once a minute.")]
     [Command("reminder")]
     [Alias("settimer", "remindme")]
     [RateLimit(3, 10)]


### PR DESCRIPTION
## Summary
- Correct the reminder command summary to document its enforced one-minute minimum instead of the obsolete five-second minimum.

## Verification
- `dotnet build` — passed (0 errors; existing NU1903 advisory warning for SQLitePCLRaw.lib.e_sqlite3 2.1.6).
- `dotnet test` — passed (188 tests, 0 failed, 0 skipped; same NU1903 warning).
- `git diff --check` — passed.

## Risk
- Low: documentation metadata only; runtime behavior is unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
