### PR TITLE
fix: refresh stored channel names

### DIFF
--- a/Morpheus.Tests/ChannelServiceTests.cs
+++ b/Morpheus.Tests/ChannelServiceTests.cs
@@ -1,0 +1,41 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class ChannelServiceTests
+{
+    [Fact]
+    public async Task TryGetCreateChannel_UpdatesStoredNameForExistingChannel()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        Channel channel = new()
+        {
+            DiscordId = 123,
+            Name = "old-name"
+        };
+        await db.Channels.AddAsync(channel);
+        await db.SaveChangesAsync();
+
+        ChannelService service = new(db, new LogsService(new LogQueue()));
+
+        Channel result = await service.TryGetCreateChannel(123, "new-name");
+
+        Assert.Equal("new-name", result.Name);
+
+        db.ChangeTracker.Clear();
+        Channel persisted = await db.Channels.SingleAsync(c => c.DiscordId == 123);
+        Assert.Equal("new-name", persisted.Name);
+    }
+}

--- a/Services/ChannelService.cs
+++ b/Services/ChannelService.cs
@@ -11,7 +11,15 @@ public class ChannelService(DB dbContext, LogsService logsService)
         Channel? channel = await dbContext.Channels.FirstOrDefaultAsync(c => c.DiscordId == discordId);
 
         if (channel != null)
+        {
+            if (channel.Name != name)
+            {
+                channel.Name = name;
+                await dbContext.SaveChangesAsync();
+            }
+
             return channel;
+        }
 
         channel = new Channel
         {


### PR DESCRIPTION
## Summary
- Refresh persisted channel names when Discord channels are renamed.
- Add an SQLite regression test that verifies the updated name is saved.

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~ChannelServiceTests` — passed (1 test).
- `dotnet build` — passed with the existing NU1903 warning for SQLitePCLRaw.lib.e_sqlite3 2.1.6.
- `dotnet test --no-build` — passed (189 tests).
- `git diff --check upstream/develop...HEAD` — passed.

## Risk
- Low: only existing channel rows whose stored name differs are updated; no schema or command metadata changes.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
