### PR TITLE
fix: compare button scores against all-time best

### DIFF
--- a/Modules/ButtonModule.cs
+++ b/Modules/ButtonModule.cs
@@ -46,8 +46,8 @@ public class ButtonModule(DB dbContext) : ModuleBase<SocketCommandContextExtende
             await ReplyAsync($"Congratz you are the first one to press the button! You received the impossible score of {buttonPress.Score}.");
         else
         {
-            if (buttonPress.Score > buttonGamePress.Score)
-                await ReplyAsync($"You pressed the button! You received {buttonPress.Score} points. You beat the previous best score of {buttonGamePress.Score} points.");
+            if (IsNewBestScore(buttonPress.Score, bestButtonPress?.Score))
+                await ReplyAsync($"You pressed the button! You received {buttonPress.Score} points. You beat the previous best score of {bestButtonPress!.Score} points.");
             else
                 await ReplyAsync($"You pressed the button! You received {buttonPress.Score} points. The most recent score was {buttonGamePress.Score} points.");
         }
@@ -55,6 +55,9 @@ public class ButtonModule(DB dbContext) : ModuleBase<SocketCommandContextExtende
         // Save changes to database
         await dbContext.SaveChangesAsync();
     }
+
+    internal static bool IsNewBestScore(long score, long? bestScore) =>
+        bestScore.HasValue && score > bestScore.Value;
 
     // Top global 
     [Name("Top Button Global")]

--- a/Morpheus.Tests/ButtonModuleTests.cs
+++ b/Morpheus.Tests/ButtonModuleTests.cs
@@ -1,0 +1,19 @@
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class ButtonModuleTests
+{
+    [Theory]
+    [InlineData(10L, 100L, false)]
+    [InlineData(101L, 100L, true)]
+    [InlineData(100L, 100L, false)]
+    [InlineData(1L, null, false)]
+    public void IsNewBestScore_ComparesAgainstHighestPreviousScore(
+        long score,
+        long? bestScore,
+        bool expected)
+    {
+        Assert.Equal(expected, ButtonModule.IsNewBestScore(score, bestScore));
+    }
+}


### PR DESCRIPTION
## Summary
- compare new button-game scores with the all-time high instead of only the most recent press
- report the actual previous best score when a record is broken
- add regression coverage for below, equal, above, and missing previous-best values

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~ButtonModuleTests --nologo` — passed: 4 tests
- `dotnet test --nologo` — passed: 192 tests
- `dotnet build --nologo` — passed: 0 errors (existing NU1903 SQLite advisory warning)
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change only corrects record detection and its response text; persistence and score calculation are unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
