### PR TITLE
fix: reject reversed activity date ranges

### DIFF
--- a/Morpheus.Tests/ActivityGraphServiceTests.cs
+++ b/Morpheus.Tests/ActivityGraphServiceTests.cs
@@ -55,6 +55,20 @@ public class ActivityGraphServiceTests
     }
 
     [Fact]
+    public void ParseDaysString_RejectsReversedDateRange()
+    {
+        ActivityGraphParseResult result = ActivityGraphService.ParseDaysString(
+            "2026-05-02..2026-05-01",
+            isOwner: false,
+            maxDays: 90);
+
+        Assert.False(result.Success);
+        Assert.Equal(
+            "Invalid date range format. Use YYYY-MM-DD..YYYY-MM-DD and ensure the range is at most 90 days and start <= end.",
+            result.ErrorMessage);
+    }
+
+    [Fact]
     public void ResolveRange_UsesTrailingInclusiveWindowWhenNoExplicitStartExists()
     {
         ActivityGraphParseResult parse = ActivityGraphParseResult.Valid(days: 7, explicitStart: null);

--- a/Services/ActivityGraphService.cs
+++ b/Services/ActivityGraphService.cs
@@ -146,7 +146,10 @@ public class ActivityGraphService(DB dbContext)
         start = start.Date;
         end = end.Date;
         if (end < start)
-            (start, end) = (end, start);
+        {
+            return ActivityGraphParseResult.Error(
+                $"Invalid date range format. Use YYYY-MM-DD..YYYY-MM-DD and ensure the range is at most {maxDays} days and start <= end.");
+        }
 
         double span = (end - start).TotalDays + 1;
         if (span < 7)


### PR DESCRIPTION
## Summary
- reject explicit activity graph date ranges whose end precedes their start instead of silently swapping the dates
- add regression coverage for reversed ranges

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~ActivityGraphServiceTests --nologo` — passed (10/10)
- `dotnet build --nologo` — passed (0 errors; existing NU1903 SQLite package advisory warning)
- `dotnet test --nologo` — passed (189/189)
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change only rejects malformed explicit ranges and matches the validation guidance already returned to users.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
