### PR TITLE
fix: preserve duplicate activity graph users

### DIFF
--- a/Morpheus.Tests/ActivityGraphServiceTests.cs
+++ b/Morpheus.Tests/ActivityGraphServiceTests.cs
@@ -1,9 +1,67 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
 using Morpheus.Services;
 
 namespace Morpheus.Tests;
 
 public class ActivityGraphServiceTests
 {
+    [Fact]
+    public async Task BuildUserActivityGraphAsync_PreservesUsersWithMatchingNames()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        Guild guild = new() { DiscordId = 100, Name = "Test guild" };
+        User firstUser = new() { DiscordId = 1001, Username = "matching-name" };
+        User secondUser = new() { DiscordId = 1002, Username = "matching-name" };
+        db.AddRange(guild, firstUser, secondUser);
+        await db.SaveChangesAsync();
+
+        DateTime start = new(2026, 5, 24, 0, 0, 0, DateTimeKind.Utc);
+        db.UserActivity.AddRange(
+            new UserActivity
+            {
+                UserId = firstUser.Id,
+                GuildId = guild.Id,
+                DiscordChannelId = 2001,
+                DiscordMessageId = 3001,
+                XpGained = 20,
+                InsertDate = start
+            },
+            new UserActivity
+            {
+                UserId = secondUser.Id,
+                GuildId = guild.Id,
+                DiscordChannelId = 2001,
+                DiscordMessageId = 3002,
+                XpGained = 10,
+                InsertDate = start
+            });
+        await db.SaveChangesAsync();
+
+        ActivityGraphService service = new(db);
+        ActivityGraphBuildResult result = await service.BuildUserActivityGraphAsync(
+            new ActivityGraphRange(Days: 7, Start: start, ExplicitStart: start),
+            guildId: guild.Id,
+            global: false,
+            mentionedDiscordIds: [],
+            cumulative: false,
+            rollingWindowDays: null);
+
+        Assert.Equal(2, result.Series.Count);
+        Assert.Equal(20, result.Series["matching-name"][0]);
+        Assert.Equal(10, result.Series["matching-name (1002)"][0]);
+    }
+
     [Fact]
     public void ParseDaysString_ClampsPresetDaysForNonOwner()
     {

--- a/Services/ActivityGraphService.cs
+++ b/Services/ActivityGraphService.cs
@@ -300,18 +300,21 @@ public class ActivityGraphService(DB dbContext)
             baselineMap = baseList.ToDictionary(x => x.UserId, x => x.Baseline);
         }
 
-        Dictionary<int, string> names = await dbContext.Users
+        var users = await dbContext.Users
             .AsNoTracking()
             .Where(user => userIds.Contains(user.Id))
-            .Select(user => new { user.Id, user.Username })
-            .ToDictionaryAsync(user => user.Id, user => user.Username);
+            .Select(user => new { user.Id, user.Username, user.DiscordId })
+            .ToListAsync();
+        Dictionary<int, (string Username, ulong DiscordId)> userLabels = users
+            .ToDictionary(user => user.Id, user => (user.Username, user.DiscordId));
 
         Dictionary<string, List<int>> series = [];
+        HashSet<string> usedLabels = [];
         foreach (UserActivityAggregate userAgg in perUser)
         {
-            string label = names.TryGetValue(userAgg.UserId, out string? username)
-                ? username
-                : userAgg.UserId.ToString();
+            string label = userLabels.TryGetValue(userAgg.UserId, out (string Username, ulong DiscordId) user)
+                ? GetUniqueUserLabel(user.Username, user.DiscordId, usedLabels)
+                : GetUniqueUserLabel(userAgg.UserId.ToString(), (ulong)userAgg.UserId, usedLabels);
 
             List<int> daily = BuildDailyValues(userAgg.ByDay, start, days);
             series[label] = cumulative
@@ -320,6 +323,20 @@ public class ActivityGraphService(DB dbContext)
         }
 
         return series;
+    }
+
+    private static string GetUniqueUserLabel(string username, ulong discordId, HashSet<string> usedLabels)
+    {
+        string baseLabel = string.IsNullOrWhiteSpace(username) ? discordId.ToString() : username;
+        if (usedLabels.Add(baseLabel))
+            return baseLabel;
+
+        string label = $"{baseLabel} ({discordId})";
+        int suffix = 2;
+        while (!usedLabels.Add(label))
+            label = $"{baseLabel} ({discordId}, {suffix++})";
+
+        return label;
     }
 
     private async Task<Dictionary<DateTime, int>> GetGuildAggregateByDayAsync(DateTime start, int days, int guildId)


### PR DESCRIPTION
## Summary
- preserve every activity graph series when multiple Discord users share the same username
- append the affected user's Discord ID to colliding labels instead of overwriting an earlier series
- add an SQLite regression test covering duplicate usernames with distinct activity totals

## Verification
- `dotnet build` — passed with 0 errors (the existing NU1903 SQLite package warning remains)
- `dotnet test --no-build --verbosity minimal` — passed, 189 tests
- `git diff --check` — passed

## Risk
- Low: the change is limited to activity graph label generation; unique usernames retain their existing labels.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
