### PR TITLE
fix: use fractional XP level ratio

### DIFF
--- a/Morpheus.Tests/ActivityLevelServiceTests.cs
+++ b/Morpheus.Tests/ActivityLevelServiceTests.cs
@@ -9,6 +9,8 @@ public class ActivityLevelServiceTests
     [InlineData(998, 0)]
     [InlineData(999, 1)]
     [InlineData(1000, 1)]
+    [InlineData(1449, 1)]
+    [InlineData(1450, 2)]
     public void CalculateLevel_ReturnsExpectedBoundaryLevels(long xp, int expectedLevel)
     {
         Assert.Equal(expectedLevel, ActivityLevelService.CalculateLevel(xp));

--- a/Services/ActivityLevelService.cs
+++ b/Services/ActivityLevelService.cs
@@ -68,7 +68,7 @@ public class ActivityLevelService(DB dbContext)
 
     public static int CalculateLevel(long xp)
     {
-        return (int)Math.Pow(Math.Log10((xp + 111) / 111), 5.0243);
+        return (int)Math.Pow(Math.Log10((xp + 111d) / 111d), 5.0243);
     }
 
     public static int CalculateXp(int level)


### PR DESCRIPTION
## Summary
- calculate activity levels with a fractional XP ratio instead of truncating the ratio through integer division
- add regression coverage around the level 2 threshold (1,449/1,450 XP)

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore` — passed: 190 tests
- `dotnet build --no-restore` — passed with the existing NU1903 advisory warning for SQLitePCLRaw.lib.e_sqlite3 2.1.6
- `git diff --check` — passed

## Risk
- Low: the change restores the precision implied by the logarithmic formula and its inverse; it only affects XP values in ranges previously delayed by integer truncation.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
