### PR TITLE
fix: exclude empty global message users

### DIFF
--- a/Morpheus.Tests/ActivityLeaderboardServiceTests.cs
+++ b/Morpheus.Tests/ActivityLeaderboardServiceTests.cs
@@ -1,3 +1,7 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
 using Morpheus.Services;
 
 namespace Morpheus.Tests;
@@ -71,5 +75,37 @@ public class ActivityLeaderboardServiceTests
 
             """,
             message.ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public async Task GetGlobalMessageLeaderboardAsync_ExcludesUsersWithoutMessages()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        User activeUser = new() { DiscordId = 1, Username = "active" };
+        User inactiveUser = new() { DiscordId = 2, Username = "inactive" };
+        Guild guild = new() { DiscordId = 1, Name = "Test guild" };
+        db.AddRange(activeUser, inactiveUser, guild);
+        await db.SaveChangesAsync();
+
+        db.UserLevels.AddRange(
+            new UserLevels { UserId = activeUser.Id, GuildId = guild.Id, UserMessageCount = 5 },
+            new UserLevels { UserId = inactiveUser.Id, GuildId = guild.Id, UserMessageCount = 0 });
+        await db.SaveChangesAsync();
+
+        ActivityLeaderboardService service = new(db);
+        ActivityLeaderboardQueryResult result = await service.GetGlobalMessageLeaderboardAsync(null, page: 1);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Page);
+        Assert.Equal(["[1] | active: Messages 5"], result.Page.Lines);
+        Assert.Equal(1, result.Page.TotalPages);
     }
 }

--- a/Services/ActivityLeaderboardService.cs
+++ b/Services/ActivityLeaderboardService.cs
@@ -198,6 +198,7 @@ public class ActivityLeaderboardService(DB dbContext)
             .AsNoTracking()
             .GroupBy(ul => ul.UserId)
             .Select(g => new { UserId = g.Key, Value = g.Sum(ul => ul.UserMessageCount) })
+            .Where(x => x.Value > 0)
             .OrderByDescending(x => x.Value);
 
         int totalUsers = await query.CountAsync();


### PR DESCRIPTION
## Summary
- exclude users whose aggregated message count is zero from the global all-time message leaderboard
- add an in-memory SQLite regression test covering active and zero-message users

## Verification
- `dotnet build` — passed (0 errors; existing NU1903 warning for SQLitePCLRaw.lib.e_sqlite3)
- `dotnet test --no-build` — passed (189 tests)
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- low: the change only filters empty aggregate rows before leaderboard counting and pagination

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
