### PR TITLE
fix: propagate RSS feed cancellation

### DIFF
--- a/Morpheus.Tests/RssFeedServiceTests.cs
+++ b/Morpheus.Tests/RssFeedServiceTests.cs
@@ -1,0 +1,17 @@
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class RssFeedServiceTests
+{
+    [Fact]
+    public async Task FetchAsync_WhenCallerCancels_PropagatesCancellation()
+    {
+        RssFeedService service = new(new LogsService(new LogQueue()));
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.FetchAsync("https://example.com/feed.xml", cts.Token));
+    }
+}

--- a/Services/RssFeedService.cs
+++ b/Services/RssFeedService.cs
@@ -24,7 +24,7 @@ public class RssFeedService(LogsService logsService)
 
     /// <summary>
     /// Fetches a feed and returns its title + icon (if any) plus the parsed entries. Returns
-    /// (null, null, empty) on any error, and null title when the feed has no title element.
+    /// (null, null, empty) on errors other than caller cancellation, and null title when the feed has no title element.
     /// </summary>
     public async Task<(string? FeedTitle, string? FeedImageUrl, IReadOnlyList<FeedEntry> Entries)> FetchAsync(string feedUrl, CancellationToken ct = default)
     {
@@ -84,6 +84,10 @@ public class RssFeedService(LogsService logsService)
                 string.IsNullOrWhiteSpace(feedTitle) ? null : feedTitle.Trim(),
                 string.IsNullOrWhiteSpace(feedImage) ? null : feedImage.Trim(),
                 entries);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- propagate caller-requested cancellation from `RssFeedService.FetchAsync` instead of treating it as a feed failure
- keep HTTP timeouts and other fetch/parse failures on the existing empty-result path
- add a regression test for an already-cancelled caller token

## Verification
- `dotnet build` — passed (0 errors; existing NU1903 warning for SQLitePCLRaw.lib.e_sqlite3)
- `dotnet test` — passed (189 tests; existing NU1903 warning for SQLitePCLRaw.lib.e_sqlite3)
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change only distinguishes explicit caller cancellation from existing feed-fetch error handling.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
