### PR TITLE
fix: propagate Twitch request cancellation

### DIFF
--- a/Morpheus.Tests/TwitchServiceTests.cs
+++ b/Morpheus.Tests/TwitchServiceTests.cs
@@ -1,9 +1,28 @@
+using System.Net;
+using System.Text;
 using Morpheus.Services;
 
 namespace Morpheus.Tests;
 
 public class TwitchServiceTests
 {
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task GetUserAsync_PropagatesCallerCancellation(bool cancelDuringTokenRequest)
+    {
+        CancellationHandler handler = new(cancelDuringTokenRequest);
+        using HttpClient httpClient = new(handler);
+        TwitchService service = new(new LogsService(new LogQueue()), httpClient, "test-client", "test-secret");
+        using CancellationTokenSource cancellation = new();
+
+        Task<TwitchService.TwitchUser?> request = service.GetUserAsync("streamer", cancellation.Token);
+        await handler.RequestStarted;
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request);
+    }
+
     [Theory]
     [InlineData(3600, 3540)]
     [InlineData(60, 0)]
@@ -14,5 +33,27 @@ public class TwitchServiceTests
         TimeSpan duration = TwitchService.CalculateTokenCacheDuration(expiresInSeconds);
 
         Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), duration);
+    }
+
+    private sealed class CancellationHandler(bool blockTokenRequest) : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource requestStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task RequestStarted => requestStarted.Task;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.RequestUri?.Host == "id.twitch.tv" && !blockTokenRequest)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"token\",\"expires_in\":3600}", Encoding.UTF8, "application/json")
+                };
+            }
+
+            requestStarted.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("The canceled Twitch request unexpectedly completed.");
+        }
     }
 }

--- a/Services/TwitchService.cs
+++ b/Services/TwitchService.cs
@@ -13,16 +13,34 @@ namespace Morpheus.Services;
 /// those are absent, <see cref="IsConfigured"/> is false and all calls no-op. Uses the
 /// client-credentials (app access token) flow, caching the token until shortly before it expires.
 /// </summary>
-public class TwitchService(LogsService logsService)
+public class TwitchService
 {
-    private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
+    private static readonly HttpClient SharedHttpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
+    private readonly LogsService logsService;
+    private readonly HttpClient httpClient;
     private readonly SemaphoreSlim _tokenLock = new(1, 1);
 
-    private readonly string? _clientId = Env.Get<string?>("TWITCH_CLIENT_ID");
-    private readonly string? _clientSecret = Env.Get<string?>("TWITCH_CLIENT_SECRET");
+    private readonly string? _clientId;
+    private readonly string? _clientSecret;
 
     private string? _accessToken;
     private DateTime _tokenExpiresAt = DateTime.MinValue;
+
+    public TwitchService(LogsService logsService) : this(
+        logsService,
+        SharedHttpClient,
+        Env.Get<string?>("TWITCH_CLIENT_ID"),
+        Env.Get<string?>("TWITCH_CLIENT_SECRET"))
+    {
+    }
+
+    internal TwitchService(LogsService logsService, HttpClient httpClient, string? clientId, string? clientSecret)
+    {
+        this.logsService = logsService;
+        this.httpClient = httpClient;
+        _clientId = clientId;
+        _clientSecret = clientSecret;
+    }
 
     public bool IsConfigured => !string.IsNullOrWhiteSpace(_clientId) && !string.IsNullOrWhiteSpace(_clientSecret);
 
@@ -87,7 +105,7 @@ public class TwitchService(LogsService logsService)
 
             try
             {
-                using HttpResponseMessage resp = await HttpClient.SendAsync(req, ct).ConfigureAwait(false);
+                using HttpResponseMessage resp = await httpClient.SendAsync(req, ct).ConfigureAwait(false);
 
                 if (resp.StatusCode == HttpStatusCode.Unauthorized && attempt == 0)
                     continue; // token likely expired early — refresh and retry once
@@ -100,6 +118,10 @@ public class TwitchService(LogsService logsService)
                 }
 
                 return await resp.Content.ReadFromJsonAsync<T>(cancellationToken: ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -134,7 +156,7 @@ public class TwitchService(LogsService logsService)
             };
 
             using FormUrlEncodedContent content = new(form);
-            using HttpResponseMessage resp = await HttpClient.PostAsync(url, content, ct).ConfigureAwait(false);
+            using HttpResponseMessage resp = await httpClient.PostAsync(url, content, ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {
                 string body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
@@ -150,6 +172,10 @@ public class TwitchService(LogsService logsService)
             // Refresh a minute early to avoid using an about-to-expire token.
             _tokenExpiresAt = DateTime.UtcNow.Add(CalculateTokenCacheDuration(token.ExpiresIn));
             return _accessToken;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- propagate caller-requested cancellation from Twitch token and Helix requests instead of treating it as an API failure
- inject the HTTP client through an internal test seam and cover cancellation during both request phases

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~TwitchServiceTests` — passed (6 tests)
- `dotnet build` — passed with 0 errors (existing NU1903 warning for SQLitePCLRaw.lib.e_sqlite3)
- `dotnet test --no-build` — passed (190 tests)
- `git diff --check` — passed

## Risk
- Low: only caller-requested cancellations change behavior; HTTP timeouts and other request failures retain the existing log-and-return behavior.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
