### PR TITLE
fix: support multi-word help lookups

### DIFF
--- a/Modules/HelpModule.cs
+++ b/Modules/HelpModule.cs
@@ -118,7 +118,7 @@ public class HelpModule : ModuleBase<SocketCommandContextExtended>
     [Command("help")]
     [Alias("commands", "cmds", "h")]
     [RateLimit(1, 30)]
-    public async Task Help(string? command = null)
+    public async Task Help([Remainder] string? command = null)
     {
         // Determine command prefix for this guild
         Guild? guild = null;

--- a/Morpheus.Tests/HelpCommandRegistrationTests.cs
+++ b/Morpheus.Tests/HelpCommandRegistrationTests.cs
@@ -1,0 +1,22 @@
+using Discord.Commands;
+using Morpheus.Modules;
+using System.Reflection;
+
+namespace Morpheus.Tests;
+
+public class HelpCommandRegistrationTests
+{
+    [Fact]
+    public void HelpCommand_AcceptsMultiWordCommandNames()
+    {
+        MethodInfo method = Assert.Single(
+            typeof(HelpModule).GetMethods(),
+            method => method.GetCustomAttributes<CommandAttribute>()
+                .Any(attribute => attribute.Text == "help"));
+        System.Reflection.ParameterInfo parameter = Assert.Single(method.GetParameters());
+
+        Assert.NotNull(parameter.GetCustomAttribute<RemainderAttribute>());
+        Assert.True(parameter.HasDefaultValue);
+        Assert.Null(parameter.DefaultValue);
+    }
+}


### PR DESCRIPTION
## Summary
- allow the help command to consume complete multi-word command names and aliases
- add a registration regression test for the remainder parameter

## Verification
- `dotnet build` — passed (2 existing NU1903 vulnerability warnings)
- `dotnet test --no-build` — passed (189 tests)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter FullyQualifiedName~HelpCommandRegistrationTests` — passed (1 test)
- `python3 tools/generate_commands_md.py` — ran; COMMANDS.md has no semantic command change, so platform-only path separator churn was not included
- `git diff --check` — passed

## Risk
- Low: one command-parser annotation plus a focused metadata regression test; the parameter remains optional for bare `help` calls.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
