### PR TITLE
fix: retry failed reminder deliveries

### DIFF
--- a/Database/Models/Reminder.cs
+++ b/Database/Models/Reminder.cs
@@ -21,6 +21,12 @@ public class Reminder
     [Required]
     public DateTime DueDate { get; set; }
 
+    public int DeliveryFailureCount { get; set; }
+
+    public DateTime? FirstDeliveryFailureAt { get; set; }
+
+    public DateTime? NextDeliveryAttemptAt { get; set; }
+
     public int? GuildId { get; set; }
 
     [ForeignKey(nameof(GuildId))]

--- a/Jobs/RemindersJob.cs
+++ b/Jobs/RemindersJob.cs
@@ -2,6 +2,7 @@ using Discord;
 using Discord.WebSocket;
 using Microsoft.EntityFrameworkCore;
 using Morpheus.Database;
+using Morpheus.Database.Models;
 using Morpheus.Services;
 using Quartz;
 
@@ -28,44 +29,44 @@ public class RemindersJob(LogsService logsService, DB dB, DiscordSocketClient di
 
         foreach (var reminder in dueReminders)
         {
-            try
-            {
-                // Find the channel in connected guilds
-                var channel = discordClient.GetChannel(reminder.ChannelId) as IMessageChannel;
+            // Find the channel in connected guilds
+            var channel = discordClient.GetChannel(reminder.ChannelId) as IMessageChannel;
+            Func<string, Task>? sendAsync = channel == null
+                ? null
+                : async content => await channel.SendMessageAsync(content);
 
-                if (channel == null)
-                {
-                    Log($"Channel {reminder.ChannelId} not found, deleting reminder {reminder.Id}.");
-                    dB.Reminders.Remove(reminder);
-                    continue;
-                }
-
-                string content = reminder.Text ?? string.Empty;
-
-                if (string.IsNullOrWhiteSpace(content))
-                {
-                    content = "Reminder!";
-                }
-
-                await channel.SendMessageAsync(content);
-
-                Log($"Sent reminder {reminder.Id} to channel {reminder.ChannelId}");
-
-                // Remove the reminder after sending
+            bool shouldDelete = await DeliverAsync(reminder, sendAsync, Log);
+            if (shouldDelete)
                 dB.Reminders.Remove(reminder);
-            }
-            catch (Exception ex)
-            {
-                Log($"Error sending reminder {reminder.Id} to channel {reminder.ChannelId}: {ex.Message}. Deleting reminder.");
-                try { dB.Reminders.Remove(reminder); }
-                catch (Exception ex2)
-                {
-                    logsService.Log($"Failed to remove reminder {reminder.Id}: {ex2}", LogSeverity.Warning);
-                }
-            }
         }
 
         // Persist deletions
         await dB.SaveChangesAsync();
+    }
+
+    internal static async Task<bool> DeliverAsync(
+        Reminder reminder,
+        Func<string, Task>? sendAsync,
+        Action<string> log)
+    {
+        if (sendAsync == null)
+        {
+            log($"Channel {reminder.ChannelId} not found, deleting reminder {reminder.Id}.");
+            return true;
+        }
+
+        string content = string.IsNullOrWhiteSpace(reminder.Text) ? "Reminder!" : reminder.Text;
+
+        try
+        {
+            await sendAsync(content);
+            log($"Sent reminder {reminder.Id} to channel {reminder.ChannelId}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            log($"Error sending reminder {reminder.Id} to channel {reminder.ChannelId}: {ex.Message}. Keeping reminder for retry.");
+            return false;
+        }
     }
 }

--- a/Jobs/RemindersJob.cs
+++ b/Jobs/RemindersJob.cs
@@ -10,6 +10,9 @@ namespace Morpheus.Jobs;
 
 public class RemindersJob(LogsService logsService, DB dB, DiscordSocketClient discordClient) : IJob
 {
+    internal static readonly TimeSpan MaximumRetryAge = TimeSpan.FromDays(7);
+    internal static readonly TimeSpan MaximumRetryDelay = TimeSpan.FromHours(24);
+
     private void Log(string message) => logsService.Log($"Quartz Job - {message}");
 
     public async Task Execute(IJobExecutionContext context)
@@ -18,8 +21,8 @@ public class RemindersJob(LogsService logsService, DB dB, DiscordSocketClient di
 
         // Find reminders that are due (due date <= now)
         var dueReminders = await dB.Reminders
-            .Where(r => r.DueDate <= now)
-            .OrderBy(r => r.DueDate)
+            .Where(r => (r.NextDeliveryAttemptAt ?? r.DueDate) <= now)
+            .OrderBy(r => r.NextDeliveryAttemptAt ?? r.DueDate)
             .ToListAsync();
 
         if (!dueReminders.Any())
@@ -35,7 +38,7 @@ public class RemindersJob(LogsService logsService, DB dB, DiscordSocketClient di
                 ? null
                 : async content => await channel.SendMessageAsync(content);
 
-            bool shouldDelete = await DeliverAsync(reminder, sendAsync, Log);
+            bool shouldDelete = await DeliverAsync(reminder, sendAsync, Log, now);
             if (shouldDelete)
                 dB.Reminders.Remove(reminder);
         }
@@ -47,11 +50,21 @@ public class RemindersJob(LogsService logsService, DB dB, DiscordSocketClient di
     internal static async Task<bool> DeliverAsync(
         Reminder reminder,
         Func<string, Task>? sendAsync,
-        Action<string> log)
+        Action<string> log,
+        DateTime now)
     {
         if (sendAsync == null)
         {
             log($"Channel {reminder.ChannelId} not found, deleting reminder {reminder.Id}.");
+            return true;
+        }
+
+        if (reminder.FirstDeliveryFailureAt.HasValue &&
+            now >= reminder.FirstDeliveryFailureAt.Value.Add(MaximumRetryAge))
+        {
+            log(
+                $"Reminder {reminder.Id} to channel {reminder.ChannelId} permanently failed " +
+                $"after {reminder.DeliveryFailureCount} delivery attempts over one week. Deleting reminder.");
             return true;
         }
 
@@ -65,8 +78,30 @@ public class RemindersJob(LogsService logsService, DB dB, DiscordSocketClient di
         }
         catch (Exception ex)
         {
-            log($"Error sending reminder {reminder.Id} to channel {reminder.ChannelId}: {ex.Message}. Keeping reminder for retry.");
+            reminder.FirstDeliveryFailureAt ??= now;
+            reminder.DeliveryFailureCount++;
+
+            DateTime retryDeadline = reminder.FirstDeliveryFailureAt.Value.Add(MaximumRetryAge);
+            DateTime nextAttempt = now.Add(CalculateRetryDelay(reminder.DeliveryFailureCount));
+            reminder.NextDeliveryAttemptAt = nextAttempt < retryDeadline ? nextAttempt : retryDeadline;
+
+            log(
+                $"Error sending reminder {reminder.Id} to channel {reminder.ChannelId}: {ex.Message}. " +
+                $"Retry {reminder.DeliveryFailureCount} scheduled for {reminder.NextDeliveryAttemptAt:u}.");
             return false;
         }
+    }
+
+    internal static TimeSpan CalculateRetryDelay(int failureCount)
+    {
+        if (failureCount <= 1)
+            return TimeSpan.FromMinutes(1);
+
+        // Attempt 12 would exceed 24 hours (2^11 minutes), so cap it and every
+        // subsequent delay at one day.
+        if (failureCount >= 12)
+            return MaximumRetryDelay;
+
+        return TimeSpan.FromMinutes(1 << (failureCount - 1));
     }
 }

--- a/Migrations/20260731075933_AddReminderDeliveryBackoff.Designer.cs
+++ b/Migrations/20260731075933_AddReminderDeliveryBackoff.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Morpheus.Database;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Morpheus.Migrations
 {
     [DbContext(typeof(DB))]
-    partial class DBModelSnapshot : ModelSnapshot
+    [Migration("20260731075933_AddReminderDeliveryBackoff")]
+    partial class AddReminderDeliveryBackoff
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260731075933_AddReminderDeliveryBackoff.cs
+++ b/Migrations/20260731075933_AddReminderDeliveryBackoff.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Morpheus.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReminderDeliveryBackoff : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "DeliveryFailureCount",
+                table: "Reminders",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "FirstDeliveryFailureAt",
+                table: "Reminders",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "NextDeliveryAttemptAt",
+                table: "Reminders",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeliveryFailureCount",
+                table: "Reminders");
+
+            migrationBuilder.DropColumn(
+                name: "FirstDeliveryFailureAt",
+                table: "Reminders");
+
+            migrationBuilder.DropColumn(
+                name: "NextDeliveryAttemptAt",
+                table: "Reminders");
+        }
+    }
+}

--- a/Morpheus.Tests/RemindersJobTests.cs
+++ b/Morpheus.Tests/RemindersJobTests.cs
@@ -1,0 +1,41 @@
+using Morpheus.Database.Models;
+using Morpheus.Jobs;
+
+namespace Morpheus.Tests;
+
+public class RemindersJobTests
+{
+    [Fact]
+    public async Task DeliverAsync_WhenDeliveryFails_RetainsReminderForRetry()
+    {
+        Reminder reminder = new() { Id = 7, ChannelId = 42, Text = "Remember this" };
+        List<string> logs = [];
+
+        bool shouldDelete = await RemindersJob.DeliverAsync(
+            reminder,
+            _ => Task.FromException(new InvalidOperationException("Discord unavailable")),
+            logs.Add);
+
+        Assert.False(shouldDelete);
+        Assert.Contains(logs, message => message.Contains("Keeping reminder for retry."));
+    }
+
+    [Fact]
+    public async Task DeliverAsync_WhenDeliverySucceeds_DeletesReminder()
+    {
+        Reminder reminder = new() { Id = 7, ChannelId = 42, Text = "Remember this" };
+        List<string> sentMessages = [];
+
+        bool shouldDelete = await RemindersJob.DeliverAsync(
+            reminder,
+            content =>
+            {
+                sentMessages.Add(content);
+                return Task.CompletedTask;
+            },
+            _ => { });
+
+        Assert.True(shouldDelete);
+        Assert.Equal(["Remember this"], sentMessages);
+    }
+}

--- a/Morpheus.Tests/RemindersJobTests.cs
+++ b/Morpheus.Tests/RemindersJobTests.cs
@@ -10,14 +10,19 @@ public class RemindersJobTests
     {
         Reminder reminder = new() { Id = 7, ChannelId = 42, Text = "Remember this" };
         List<string> logs = [];
+        DateTime now = new(2026, 7, 31, 8, 0, 0, DateTimeKind.Utc);
 
         bool shouldDelete = await RemindersJob.DeliverAsync(
             reminder,
             _ => Task.FromException(new InvalidOperationException("Discord unavailable")),
-            logs.Add);
+            logs.Add,
+            now);
 
         Assert.False(shouldDelete);
-        Assert.Contains(logs, message => message.Contains("Keeping reminder for retry."));
+        Assert.Equal(1, reminder.DeliveryFailureCount);
+        Assert.Equal(now, reminder.FirstDeliveryFailureAt);
+        Assert.Equal(now.AddMinutes(1), reminder.NextDeliveryAttemptAt);
+        Assert.Contains(logs, message => message.Contains("Retry 1 scheduled"));
     }
 
     [Fact]
@@ -33,9 +38,53 @@ public class RemindersJobTests
                 sentMessages.Add(content);
                 return Task.CompletedTask;
             },
-            _ => { });
+            _ => { },
+            DateTime.UtcNow);
 
         Assert.True(shouldDelete);
         Assert.Equal(["Remember this"], sentMessages);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 4)]
+    [InlineData(11, 1024)]
+    [InlineData(12, 1440)]
+    [InlineData(100, 1440)]
+    public void CalculateRetryDelay_DoublesAndCapsAtOneDay(int failureCount, int expectedMinutes)
+    {
+        Assert.Equal(TimeSpan.FromMinutes(expectedMinutes), RemindersJob.CalculateRetryDelay(failureCount));
+    }
+
+    [Fact]
+    public async Task DeliverAsync_AtOneWeekDeadline_PermanentlyFailsWithoutSending()
+    {
+        DateTime firstFailure = new(2026, 7, 24, 8, 0, 0, DateTimeKind.Utc);
+        Reminder reminder = new()
+        {
+            Id = 7,
+            ChannelId = 42,
+            Text = "Remember this",
+            DeliveryFailureCount = 14,
+            FirstDeliveryFailureAt = firstFailure,
+            NextDeliveryAttemptAt = firstFailure.Add(RemindersJob.MaximumRetryAge)
+        };
+        bool sendAttempted = false;
+        List<string> logs = [];
+
+        bool shouldDelete = await RemindersJob.DeliverAsync(
+            reminder,
+            _ =>
+            {
+                sendAttempted = true;
+                return Task.CompletedTask;
+            },
+            logs.Add,
+            firstFailure.Add(RemindersJob.MaximumRetryAge));
+
+        Assert.True(shouldDelete);
+        Assert.False(sendAttempted);
+        Assert.Contains(logs, message => message.Contains("permanently failed"));
     }
 }


### PR DESCRIPTION
## Summary

- Retry transient reminder delivery failures instead of deleting the reminder immediately.
- Persist the delivery failure count, first failure time, and next delivery attempt.
- Use exponential backoff: 1 minute, 2 minutes, 4 minutes, 8 minutes, and so on.
- Cap the delay between attempts at 24 hours.
- Permanently fail and delete the reminder one week after its first delivery failure, without making an attempt after the deadline.
- Preserve the existing behavior for successful deliveries and missing channels: delete the reminder immediately.

## Database

- Adds an EF-generated `AddReminderDeliveryBackoff` migration with `DeliveryFailureCount`, `FirstDeliveryFailureAt`, and `NextDeliveryAttemptAt` on reminders.
- The migration was generated after syncing with current `develop`; EF reports no pending model changes.

## Verification

- Reminder job tests: 9/9 passed.
- Build passed (with the repository's existing NU1903 advisory warning).
- Full suite: 225 passed, with only the known Windows CRLF baseline failure in `ActivityLeaderboardServiceTests.FormatLeaderboardMessage_UsesExistingCodeBlockShape`.
- Generated migration SQL inspected and contains only the three expected reminder columns.
- `git diff --check` passed.

## Risk

Low to medium. Transiently failed reminders may arrive late, but retry state is persisted, intervals are bounded to 24 hours, and retries terminate after one week.