### PR TITLE
fix: propagate YouTube feed cancellation

### DIFF
--- a/Morpheus.Tests/YoutubeFeedServiceTests.cs
+++ b/Morpheus.Tests/YoutubeFeedServiceTests.cs
@@ -1,0 +1,17 @@
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class YoutubeFeedServiceTests
+{
+    [Fact]
+    public async Task FetchFeedAsync_WhenCallerCancels_PropagatesCancellation()
+    {
+        YoutubeFeedService service = new(new LogsService(new LogQueue()));
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.FetchFeedAsync("channel-id", cts.Token));
+    }
+}

--- a/Services/YoutubeFeedService.cs
+++ b/Services/YoutubeFeedService.cs
@@ -43,6 +43,10 @@ public class YoutubeFeedService(LogsService logsService)
 
             return (channelTitle, entries);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logsService.Log($"Failed to fetch YouTube feed for {channelId}: {ex.Message}", LogSeverity.Warning);


### PR DESCRIPTION
## Summary
- propagate caller-requested cancellation from YouTube RSS feed fetches instead of treating it as a feed failure
- add a regression test using an already-cancelled token

## Verification
- `dotnet test --filter FullyQualifiedName~YoutubeFeedServiceTests --no-restore` — passed: 1 test
- `dotnet build` — passed with the existing NU1903 package vulnerability warning
- `dotnet test --no-build` — passed: 189 tests
- `git diff --check` — passed

## Risk
- Low: the behavior changes only when the supplied cancellation token requested cancellation; other fetch and parsing errors remain logged and converted to an empty result.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
