### PR TITLE
feat: add MCP server for AI agent interactions

### DIFF
--- a/MCP/McpApiExtensions.cs
+++ b/MCP/McpApiExtensions.cs
@@ -1,0 +1,331 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json;
+
+namespace Morpheus.MCP;
+
+/// <summary>
+/// Extension methods for registering and mapping the MCP API endpoints.
+/// Follows the same pattern as the Dashboard API.
+/// </summary>
+public static class McpApiExtensions
+{
+    private const string CorsPolicyName = "McpCors";
+
+    private static readonly IReadOnlyList<McpToolDefinition> ToolDefinitions =
+    [
+        new McpToolDefinition(
+            "get_user_stats",
+            "Get detailed statistics for a user including balance, XP, messages, level, quotes, and activity.",
+            [
+                new McpToolParameter("userId", "integer", "Internal user ID (optional if discordId is provided)", false),
+                new McpToolParameter("discordId", "string", "Discord user ID (optional if userId is provided)", false),
+            ]),
+        new McpToolDefinition(
+            "get_guild_info",
+            "Get information about a Discord server/guild including settings, activity stats, and quote count.",
+            [
+                new McpToolParameter("guildId", "integer", "Internal guild ID (optional if discordId is provided)", false),
+                new McpToolParameter("discordId", "string", "Discord guild ID (optional if guildId is provided)", false),
+            ]),
+        new McpToolDefinition(
+            "get_economy_summary",
+            "Get overall economy summary including total balances, UBI pool size, slots vault, and stock market info.",
+            []),
+        new McpToolDefinition(
+            "get_activity_overview",
+            "Get global activity overview including total messages, XP, active users, and server counts.",
+            []),
+        new McpToolDefinition(
+            "get_guilds",
+            "List all Discord servers the bot is connected to with their activity stats.",
+            []),
+        new McpToolDefinition(
+            "get_users",
+            "Get a paginated list of all known users.",
+            [
+                new McpToolParameter("page", "integer", "Page number (default: 1)", false, 1),
+                new McpToolParameter("limit", "integer", "Results per page (default: 20, max: 100)", false, 20),
+            ]),
+        new McpToolDefinition(
+            "get_quotes",
+            "Get a paginated list of quotes with optional filtering by guild, sort order, and approval status.",
+            [
+                new McpToolParameter("page", "integer", "Page number (default: 1)", false, 1),
+                new McpToolParameter("sort", "string", "Sort order: newest, oldest, or score (default: newest)", false, "newest"),
+                new McpToolParameter("approvedOnly", "boolean", "Only show approved quotes (default: true)", false, true),
+                new McpToolParameter("guildId", "integer", "Filter by guild ID (optional)", false),
+            ]),
+        new McpToolDefinition(
+            "get_quote_by_id",
+            "Get detailed information about a specific quote by its ID.",
+            [
+                new McpToolParameter("quoteId", "integer", "Quote ID", true),
+            ]),
+        new McpToolDefinition(
+            "get_recent_logs",
+            "Get recent bot log entries, optionally filtered by severity level.",
+            [
+                new McpToolParameter("limit", "integer", "Number of entries (default: 20, max: 100)", false, 20),
+                new McpToolParameter("severity", "string", "Filter by severity: Info, Warning, Error, Verbose, Debug (optional)", false),
+            ]),
+        new McpToolDefinition(
+            "get_stock_summary",
+            "Get stock market summary including total stocks, top gainers, and top losers.",
+            [
+                new McpToolParameter("limit", "integer", "Number of gainers/losers to return (default: 5)", false, 5),
+            ]),
+        new McpToolDefinition(
+            "get_leaderboard",
+            "Get activity leaderboard by XP or messages, optionally filtered by guild and time period.",
+            [
+                new McpToolParameter("metric", "string", "Metric: xp or messages (default: xp)", false, "xp"),
+                new McpToolParameter("guildId", "integer", "Filter by guild ID (optional)", false),
+                new McpToolParameter("days", "integer", "Lookback period in days (default: 30)", false, 30),
+                new McpToolParameter("limit", "integer", "Number of entries (default: 10, max: 50)", false, 10),
+            ]),
+    ];
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+
+    /// <summary>
+    /// Registers MCP API services in the DI container.
+    /// </summary>
+    public static IServiceCollection AddMcpApi(
+        this IServiceCollection services,
+        McpApiOptions options)
+    {
+        services.AddSingleton(options);
+        services.AddScoped<McpService>();
+
+        services.ConfigureHttpJsonOptions(jsonOptions =>
+        {
+            jsonOptions.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        });
+
+        services.AddCors(corsOptions =>
+        {
+            corsOptions.AddPolicy(CorsPolicyName, policy =>
+            {
+                policy
+                    .AllowAnyOrigin()
+                    .AllowAnyHeader()
+                    .AllowAnyMethod();
+            });
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Maps MCP API endpoints to the application.
+    /// </summary>
+    public static WebApplication MapMcpApi(this WebApplication app)
+    {
+        app.MapGet("/api/mcp", () => Results.Ok(new McpServerInfo(
+            "Morpheus MCP Server",
+            "1.0.0",
+            "/api/mcp/health",
+            "/api/mcp/tools",
+            "/api/mcp/call/{toolName}",
+            [.. ToolDefinitions.Select(t => t.Name)]
+        )));
+
+        app.MapGet("/api/mcp/health", (McpApiOptions options) => Results.Ok(new
+        {
+            status = "ok",
+            service = "Morpheus MCP Server",
+            version = "1.0.0",
+            startedAtUtc = Utilities.Env.StartTime,
+            authEnabled = !string.IsNullOrWhiteSpace(options.ApiKey)
+        }));
+
+        RouteGroupBuilder api = app
+            .MapGroup("/api/mcp")
+            .RequireCors(CorsPolicyName);
+
+        // List available tools (MCP protocol discovery)
+        api.MapGet("/tools", () => Results.Ok(new
+        {
+            tools = ToolDefinitions
+        }));
+
+        // Call a specific tool
+        api.MapPost("/call/{toolName}", async (
+            string toolName,
+            McpToolCallRequest? request,
+            McpService mcpService,
+            CancellationToken cancellationToken) =>
+        {
+            Dictionary<string, object?> parameters = request?.Params ?? [];
+
+            try
+            {
+                object? result = toolName.ToLowerInvariant() switch
+                {
+                    "get_user_stats" => await mcpService.GetUserStatsAsync(
+                        GetIntParam(parameters, "userId"),
+                        GetULongParam(parameters, "discordId"),
+                        cancellationToken),
+
+                    "get_guild_info" => await mcpService.GetGuildInfoAsync(
+                        GetIntParam(parameters, "guildId"),
+                        GetULongParam(parameters, "discordId"),
+                        cancellationToken),
+
+                    "get_economy_summary" => await mcpService.GetEconomySummaryAsync(cancellationToken),
+
+                    "get_activity_overview" => await mcpService.GetActivityOverviewAsync(cancellationToken),
+
+                    "get_guilds" => await mcpService.GetGuildsAsync(cancellationToken),
+
+                    "get_users" => await mcpService.GetUsersAsync(
+                        GetIntParam(parameters, "page") ?? 1,
+                        GetIntParam(parameters, "limit") ?? 20,
+                        cancellationToken),
+
+                    "get_quotes" => await mcpService.GetQuotesAsync(
+                        GetIntParam(parameters, "page") ?? 1,
+                        GetStringParam(parameters, "sort") ?? "newest",
+                        GetBoolParam(parameters, "approvedOnly") ?? true,
+                        GetIntParam(parameters, "guildId"),
+                        cancellationToken),
+
+                    "get_quote_by_id" => await mcpService.GetQuoteByIdAsync(
+                        GetIntParam(parameters, "quoteId") ?? throw new ArgumentException("quoteId is required"),
+                        cancellationToken),
+
+                    "get_recent_logs" => await mcpService.GetRecentLogsAsync(
+                        GetIntParam(parameters, "limit") ?? 20,
+                        GetStringParam(parameters, "severity"),
+                        cancellationToken),
+
+                    "get_stock_summary" => await mcpService.GetStockSummaryAsync(
+                        GetIntParam(parameters, "limit") ?? 5,
+                        cancellationToken),
+
+                    "get_leaderboard" => await mcpService.GetLeaderboardAsync(
+                        GetStringParam(parameters, "metric") ?? "xp",
+                        GetIntParam(parameters, "guildId"),
+                        GetIntParam(parameters, "days") ?? 30,
+                        GetIntParam(parameters, "limit") ?? 10,
+                        cancellationToken),
+
+                    _ => null
+                };
+
+                if (result is null && toolDefinitionsLut.TryGetValue(toolName.ToLowerInvariant(), out _))
+                {
+                    // Known tool but returned null (e.g. entity not found)
+                    return Results.Ok(new McpToolResponse(false, null, "Not found or no parameters provided."));
+                }
+
+                if (result is null)
+                {
+                    return Results.NotFound(new McpToolResponse(false, null, $"Unknown tool: {toolName}"));
+                }
+
+                return Results.Ok(new McpToolResponse(true, result));
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new McpToolResponse(false, null, ex.Message));
+            }
+            catch (Exception ex)
+            {
+                return Results.Ok(new McpToolResponse(false, null, $"Internal error: {ex.Message}"));
+            }
+        });
+
+        return app;
+    }
+
+    private static readonly Dictionary<string, bool> toolDefinitionsLut = ToolDefinitions
+        .ToDictionary(t => t.Name, _ => true);
+
+    // ── Parameter Helpers ──
+
+    private static int? GetIntParam(Dictionary<string, object?> parameters, string key)
+    {
+        if (!parameters.TryGetValue(key, out object? value) || value is null)
+            return null;
+
+        if (value is JsonElement je)
+        {
+            if (je.ValueKind == JsonValueKind.Number && je.TryGetInt32(out int intVal))
+                return intVal;
+            if (je.ValueKind == JsonValueKind.String && int.TryParse(je.GetString(), out int parsed))
+                return parsed;
+            return null;
+        }
+
+        if (value is int i) return i;
+        if (value is long l) return (int)l;
+        if (value is string s && int.TryParse(s, out int parsedStr)) return parsedStr;
+        return null;
+    }
+
+    private static ulong? GetULongParam(Dictionary<string, object?> parameters, string key)
+    {
+        if (!parameters.TryGetValue(key, out object? value) || value is null)
+            return null;
+
+        if (value is JsonElement je)
+        {
+            if (je.ValueKind == JsonValueKind.Number && je.TryGetUInt64(out ulong ulVal))
+                return ulVal;
+            if (je.ValueKind == JsonValueKind.String && ulong.TryParse(je.GetString(), out ulong parsed))
+                return parsed;
+            return null;
+        }
+
+        if (value is ulong ul) return ul;
+        if (value is string s && ulong.TryParse(s, out ulong parsedStr)) return parsedStr;
+        return null;
+    }
+
+    private static string? GetStringParam(Dictionary<string, object?> parameters, string key)
+    {
+        if (!parameters.TryGetValue(key, out object? value) || value is null)
+            return null;
+
+        if (value is JsonElement je)
+        {
+            return je.ValueKind switch
+            {
+                JsonValueKind.String => je.GetString(),
+                JsonValueKind.Number => je.GetRawText(),
+                JsonValueKind.True => "true",
+                JsonValueKind.False => "false",
+                _ => null
+            };
+        }
+
+        return value?.ToString();
+    }
+
+    private static bool? GetBoolParam(Dictionary<string, object?> parameters, string key)
+    {
+        if (!parameters.TryGetValue(key, out object? value) || value is null)
+            return null;
+
+        if (value is JsonElement je)
+        {
+            if (je.ValueKind == JsonValueKind.True) return true;
+            if (je.ValueKind == JsonValueKind.False) return false;
+            if (je.ValueKind == JsonValueKind.String && bool.TryParse(je.GetString(), out bool parsed))
+                return parsed;
+            return null;
+        }
+
+        if (value is bool b) return b;
+        if (value is string s && bool.TryParse(s, out bool parsedStr)) return parsedStr;
+        return null;
+    }
+}

--- a/MCP/McpApiOptions.cs
+++ b/MCP/McpApiOptions.cs
@@ -1,0 +1,18 @@
+using Morpheus.Utilities;
+
+namespace Morpheus.MCP;
+
+/// <summary>
+/// Configuration options for the MCP API server.
+/// </summary>
+public sealed record McpApiOptions(
+    string Urls,
+    string ApiKey)
+{
+    public static McpApiOptions FromEnvironment()
+    {
+        string urls = Env.Get("MCP_API_URLS", "http://127.0.0.1:5268");
+        string apiKey = Env.Get("MCP_API_KEY", string.Empty);
+        return new McpApiOptions(urls, apiKey);
+    }
+}

--- a/MCP/McpContracts.cs
+++ b/MCP/McpContracts.cs
@@ -1,0 +1,208 @@
+using System.Text.Json.Serialization;
+
+namespace Morpheus.MCP;
+
+/// <summary>
+/// MCP tool definition returned by the /tools endpoint.
+/// Describes a callable tool, its parameters, and purpose.
+/// </summary>
+public sealed record McpToolDefinition(
+    string Name,
+    string Description,
+    IReadOnlyList<McpToolParameter> Parameters);
+
+/// <summary>
+/// Describes a single parameter for an MCP tool.
+/// </summary>
+public sealed record McpToolParameter(
+    string Name,
+    string Type,
+    string Description,
+    bool Required = false,
+    object? Default = null);
+
+/// <summary>
+/// MCP server info response.
+/// </summary>
+public sealed record McpServerInfo(
+    string Service,
+    string Version,
+    string Health,
+    string Tools,
+    string Call,
+    string[] AvailableTools);
+
+/// <summary>
+/// Request body for calling an MCP tool.
+/// </summary>
+public sealed record McpToolCallRequest(
+    [property: JsonPropertyName("params")]
+    Dictionary<string, object?>? Params);
+
+/// <summary>
+/// Successful MCP tool response.
+/// </summary>
+public sealed record McpToolResponse(
+    bool Success,
+    object? Data,
+    string? Error = null);
+
+/// <summary>
+/// User stats response.
+/// </summary>
+public sealed record McpUserStats(
+    int Id,
+    ulong DiscordId,
+    string Username,
+    DateTime CreatedAtUtc,
+    decimal Balance,
+    int TotalMessages,
+    long TotalXp,
+    int? Level,
+    int QuoteCount,
+    int QuoteScore,
+    int ButtonScore,
+    DateTime? LastActivityAtUtc);
+
+/// <summary>
+/// Guild info response.
+/// </summary>
+public sealed record McpGuildInfo(
+    int Id,
+    ulong DiscordId,
+    string Name,
+    DateTime CreatedAtUtc,
+    string Prefix,
+    int TrackedUsers,
+    long Messages,
+    long Xp,
+    int ApprovedQuotes,
+    bool UseGlobalQuotes,
+    bool WelcomeMessages,
+    bool UseActivityRoles);
+
+/// <summary>
+/// Economy summary response.
+/// </summary>
+public sealed record McpEconomySummary(
+    int TotalUsers,
+    decimal TotalBalance,
+    decimal AverageBalance,
+    decimal UbiPoolSize,
+    decimal SlotsVaultSize,
+    int TotalStocks,
+    decimal TotalStockPortfolioValue);
+
+/// <summary>
+/// Activity overview response.
+/// </summary>
+public sealed record McpActivityOverview(
+    long TotalMessages,
+    long TotalXp,
+    int ActiveUsersLast30Days,
+    long MessagesLast30Days,
+    long XpLast30Days,
+    int TotalServers,
+    int TotalKnownUsers,
+    DateTime? LastActivityAtUtc);
+
+/// <summary>
+/// Server list item.
+/// </summary>
+public sealed record McpServerItem(
+    int Id,
+    ulong DiscordId,
+    string Name,
+    DateTime CreatedAtUtc,
+    int TrackedUsers,
+    long Messages,
+    long Xp,
+    int ApprovedQuotes);
+
+/// <summary>
+/// User list item.
+/// </summary>
+public sealed record McpUserItem(
+    int Id,
+    ulong DiscordId,
+    string Username,
+    DateTime CreatedAtUtc,
+    decimal Balance,
+    long Messages,
+    long Xp,
+    int? Level);
+
+/// <summary>
+/// Leaderboard entry.
+/// </summary>
+public sealed record McpLeaderboardEntry(
+    int Rank,
+    int UserId,
+    ulong DiscordId,
+    string Username,
+    long Value,
+    int? Level);
+
+/// <summary>
+/// Page of quotes.
+/// </summary>
+public sealed record McpQuotePage(
+    int Page,
+    int TotalPages,
+    int Total,
+    IReadOnlyList<McpQuoteItem> Items);
+
+/// <summary>
+/// Single quote item.
+/// </summary>
+public sealed record McpQuoteItem(
+    int Id,
+    int GuildId,
+    int UserId,
+    string Author,
+    string Content,
+    DateTime InsertedAtUtc,
+    bool Approved,
+    bool Removed,
+    int Score);
+
+/// <summary>
+/// Quote detail.
+/// </summary>
+public sealed record McpQuoteDetail(
+    int Id,
+    int GuildId,
+    string Content,
+    DateTime InsertedAtUtc,
+    bool Approved,
+    bool Removed,
+    int TotalScore,
+    string Author);
+
+/// <summary>
+/// Moderation log entry.
+/// </summary>
+public sealed record McpModerationEntry(
+    long Id,
+    string Severity,
+    string Message,
+    DateTime InsertedAtUtc);
+
+/// <summary>
+/// Stock market summary.
+/// </summary>
+public sealed record McpStockSummary(
+    int TotalStocks,
+    IReadOnlyList<McpStockItem> TopGainers,
+    IReadOnlyList<McpStockItem> TopLosers);
+
+/// <summary>
+/// Stock market item.
+/// </summary>
+public sealed record McpStockItem(
+    int StockId,
+    string EntityType,
+    int EntityId,
+    string Name,
+    decimal Price,
+    decimal DailyChangePercent);

--- a/MCP/McpService.cs
+++ b/MCP/McpService.cs
@@ -1,0 +1,561 @@
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Enums;
+using Morpheus.Database.Models;
+
+namespace Morpheus.MCP;
+
+/// <summary>
+/// Service that provides data for the MCP API endpoints.
+/// Wraps database queries to expose bot data to AI agents.
+/// </summary>
+public sealed class McpService(DB dbContext)
+{
+    private const string UbiPoolSettingKey = "ubi_pool";
+    private const string SlotsVaultSettingKey = "slots_vault";
+    private const decimal SlotsVaultDefaultAmount = 10000.00m;
+
+    /// <summary>
+    /// Gets stats for a specific user by id or discord id.
+    /// </summary>
+    public async Task<McpUserStats?> GetUserStatsAsync(int? userId, ulong? discordId, CancellationToken ct = default)
+    {
+        IQueryable<User> query = dbContext.Users.AsNoTracking();
+
+        if (userId.HasValue)
+            query = query.Where(u => u.Id == userId.Value);
+        else if (discordId.HasValue)
+            query = query.Where(u => u.DiscordId == discordId.Value);
+        else
+            return null;
+
+        User? user = await query.FirstOrDefaultAsync(ct);
+        if (user == null) return null;
+
+        var levels = await dbContext.UserLevels
+            .AsNoTracking()
+            .Where(ul => ul.UserId == user.Id)
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                Messages = g.Sum(ul => (long)ul.UserMessageCount),
+                Xp = g.Sum(ul => (long)ul.TotalXp),
+                MaxLevel = g.Max(ul => (int?)ul.Level)
+            })
+            .FirstOrDefaultAsync(ct);
+
+        int quoteCount = await dbContext.Quotes
+            .AsNoTracking()
+            .CountAsync(q => q.UserId == user.Id && !q.Removed, ct);
+
+        int quoteScore = await dbContext.QuoteScores
+            .AsNoTracking()
+            .Where(qs => qs.UserId == user.Id)
+            .SumAsync(qs => (int?)qs.Score, ct) ?? 0;
+
+        int buttonScore = await dbContext.ButtonGamePresses
+            .AsNoTracking()
+            .CountAsync(bp => bp.UserId == user.Id, ct);
+
+        DateTime? lastActivity = await dbContext.UserActivity
+            .AsNoTracking()
+            .Where(ua => ua.UserId == user.Id)
+            .Select(ua => (DateTime?)ua.InsertDate)
+            .MaxAsync(ct);
+
+        return new McpUserStats(
+            user.Id,
+            user.DiscordId,
+            user.Username,
+            user.InsertDate,
+            user.Balance,
+            (int)(levels?.Messages ?? 0),
+            levels?.Xp ?? 0,
+            levels?.MaxLevel,
+            quoteCount,
+            quoteScore,
+            buttonScore,
+            lastActivity);
+    }
+
+    /// <summary>
+    /// Gets guild info by id or discord id.
+    /// </summary>
+    public async Task<McpGuildInfo?> GetGuildInfoAsync(int? guildId, ulong? discordId, CancellationToken ct = default)
+    {
+        IQueryable<Guild> query = dbContext.Guilds.AsNoTracking();
+
+        if (guildId.HasValue)
+            query = query.Where(g => g.Id == guildId.Value);
+        else if (discordId.HasValue)
+            query = query.Where(g => g.DiscordId == discordId.Value);
+        else
+            return null;
+
+        Guild? guild = await query.FirstOrDefaultAsync(ct);
+        if (guild == null) return null;
+
+        var levels = await dbContext.UserLevels
+            .AsNoTracking()
+            .Where(ul => ul.GuildId == guild.Id)
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                Messages = g.Sum(ul => (long)ul.UserMessageCount),
+                Xp = g.Sum(ul => (long)ul.TotalXp),
+                Users = g.Count()
+            })
+            .FirstOrDefaultAsync(ct);
+
+        int approvedQuotes = await dbContext.Quotes
+            .AsNoTracking()
+            .CountAsync(q => q.GuildId == guild.Id && q.Approved && !q.Removed, ct);
+
+        return new McpGuildInfo(
+            guild.Id,
+            guild.DiscordId,
+            guild.Name,
+            guild.InsertDate,
+            guild.Prefix,
+            levels?.Users ?? 0,
+            levels?.Messages ?? 0,
+            levels?.Xp ?? 0,
+            approvedQuotes,
+            guild.UseGlobalQuotes,
+            guild.WelcomeMessages,
+            guild.UseActivityRoles);
+    }
+
+    /// <summary>
+    /// Gets economy summary: total balances, pool, vault, stocks.
+    /// </summary>
+    public async Task<McpEconomySummary> GetEconomySummaryAsync(CancellationToken ct = default)
+    {
+        int totalUsers = await dbContext.Users.AsNoTracking().CountAsync(ct);
+        decimal totalBalance = (await dbContext.Users
+            .AsNoTracking()
+            .Select(u => u.Balance)
+            .ToListAsync(ct))
+            .Sum();
+
+        decimal averageBalance = totalUsers > 0 ? totalBalance / totalUsers : 0m;
+
+        decimal ubiPool = await GetBotSettingDecimalAsync(UbiPoolSettingKey, 0m, ct);
+        decimal slotsVault = await GetBotSettingDecimalAsync(SlotsVaultSettingKey, SlotsVaultDefaultAmount, ct);
+
+        int totalStocks = await dbContext.Stocks.AsNoTracking().CountAsync(ct);
+        decimal totalPortfolio = (await dbContext.StockHoldings
+            .AsNoTracking()
+            .Include(sh => sh.Stock)
+            .Select(sh => sh.Shares * sh.Stock!.Price)
+            .ToListAsync(ct))
+            .Sum();
+
+        return new McpEconomySummary(
+            totalUsers,
+            totalBalance,
+            Math.Round(averageBalance, 2),
+            ubiPool,
+            slotsVault,
+            totalStocks,
+            Math.Round(totalPortfolio, 2));
+    }
+
+    /// <summary>
+    /// Gets a global activity overview.
+    /// </summary>
+    public async Task<McpActivityOverview> GetActivityOverviewAsync(CancellationToken ct = default)
+    {
+        DateTime last30Days = DateTime.UtcNow.AddDays(-30);
+
+        var levelTotals = await dbContext.UserLevels
+            .AsNoTracking()
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                Messages = g.Sum(ul => (long)ul.UserMessageCount),
+                Xp = g.Sum(ul => (long)ul.TotalXp)
+            })
+            .FirstOrDefaultAsync(ct);
+
+        long totalMessages = levelTotals?.Messages ?? 0L;
+        long totalXp = levelTotals?.Xp ?? 0L;
+
+        IQueryable<UserActivity> recentActivity = dbContext.UserActivity
+            .AsNoTracking()
+            .Where(ua => ua.InsertDate >= last30Days);
+
+        int activeUsers = await recentActivity
+            .Select(ua => ua.UserId)
+            .Distinct()
+            .CountAsync(ct);
+
+        long messagesLast30Days = await recentActivity.LongCountAsync(ct);
+        long xpLast30Days = await recentActivity
+            .SumAsync(ua => (long?)ua.XpGained, ct) ?? 0L;
+
+        int totalServers = await dbContext.Guilds.AsNoTracking().CountAsync(ct);
+        int totalUsers = await dbContext.Users.AsNoTracking().CountAsync(ct);
+
+        DateTime? lastActivity = await dbContext.UserActivity
+            .AsNoTracking()
+            .Select(ua => (DateTime?)ua.InsertDate)
+            .MaxAsync(ct);
+
+        return new McpActivityOverview(
+            totalMessages,
+            totalXp,
+            activeUsers,
+            messagesLast30Days,
+            xpLast30Days,
+            totalServers,
+            totalUsers,
+            lastActivity);
+    }
+
+    /// <summary>
+    /// Gets a list of all servers/guilds.
+    /// </summary>
+    public async Task<IReadOnlyList<McpServerItem>> GetGuildsAsync(CancellationToken ct = default)
+    {
+        var guilds = await dbContext.Guilds
+            .AsNoTracking()
+            .OrderByDescending(g => g.InsertDate)
+            .ToListAsync(ct);
+
+        var result = new List<McpServerItem>(guilds.Count);
+        foreach (Guild guild in guilds)
+        {
+            var levels = await dbContext.UserLevels
+                .AsNoTracking()
+                .Where(ul => ul.GuildId == guild.Id)
+                .GroupBy(_ => 1)
+                .Select(g => new
+                {
+                    Messages = g.Sum(ul => (long)ul.UserMessageCount),
+                    Xp = g.Sum(ul => (long)ul.TotalXp),
+                    Users = g.Count()
+                })
+                .FirstOrDefaultAsync(ct);
+
+            int approvedQuotes = await dbContext.Quotes
+                .AsNoTracking()
+                .CountAsync(q => q.GuildId == guild.Id && q.Approved && !q.Removed, ct);
+
+            result.Add(new McpServerItem(
+                guild.Id,
+                guild.DiscordId,
+                guild.Name,
+                guild.InsertDate,
+                levels?.Users ?? 0,
+                levels?.Messages ?? 0,
+                levels?.Xp ?? 0,
+                approvedQuotes));
+        }
+
+        return result.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Gets a paginated list of users.
+    /// </summary>
+    public async Task<IReadOnlyList<McpUserItem>> GetUsersAsync(int page = 1, int limit = 20, CancellationToken ct = default)
+    {
+        if (page < 1) page = 1;
+        if (limit < 1) limit = 20;
+        if (limit > 100) limit = 100;
+
+        var users = await dbContext.Users
+            .AsNoTracking()
+            .OrderByDescending(u => u.InsertDate)
+            .Skip((page - 1) * limit)
+            .Take(limit)
+            .ToListAsync(ct);
+
+        var result = new List<McpUserItem>(users.Count);
+        foreach (User user in users)
+        {
+            var levels = await dbContext.UserLevels
+                .AsNoTracking()
+                .Where(ul => ul.UserId == user.Id)
+                .GroupBy(_ => 1)
+                .Select(g => new
+                {
+                    Messages = g.Sum(ul => (long)ul.UserMessageCount),
+                    Xp = g.Sum(ul => (long)ul.TotalXp),
+                    MaxLevel = g.Max(ul => (int?)ul.Level)
+                })
+                .FirstOrDefaultAsync(ct);
+
+            result.Add(new McpUserItem(
+                user.Id,
+                user.DiscordId,
+                user.Username,
+                user.InsertDate,
+                user.Balance,
+                levels?.Messages ?? 0,
+                levels?.Xp ?? 0,
+                levels?.MaxLevel));
+        }
+
+        return result.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Gets a page of quotes.
+    /// </summary>
+    public async Task<McpQuotePage> GetQuotesAsync(
+        int page = 1,
+        string sort = "newest",
+        bool approvedOnly = true,
+        int? guildId = null,
+        CancellationToken ct = default)
+    {
+        IQueryable<Quote> query = dbContext.Quotes.AsNoTracking().Where(q => !q.Removed);
+
+        if (guildId.HasValue)
+            query = query.Where(q => q.GuildId == guildId.Value);
+
+        if (approvedOnly)
+            query = query.Where(q => q.Approved);
+
+        int total = await query.CountAsync(ct);
+        int totalPages = (int)Math.Ceiling(total / (double)10);
+        if (totalPages == 0) totalPages = 1;
+
+        if (page < 1) page = 1;
+        if (page > totalPages) page = totalPages;
+
+        query = sort.ToLowerInvariant() switch
+        {
+            "oldest" => query.OrderBy(q => q.InsertDate),
+            "score" => query.OrderByDescending(q => q.Scores.Sum(s => (int)s.Score)),
+            _ => query.OrderByDescending(q => q.InsertDate),
+        };
+
+        List<Quote> quotes = await query
+            .Skip((page - 1) * 10)
+            .Take(10)
+            .ToListAsync(ct);
+
+        if (quotes.Count == 0)
+            return new McpQuotePage(page, totalPages, total, []);
+
+        List<int> quoteIds = [.. quotes.Select(q => q.Id)];
+        Dictionary<int, int> scoreMap = await dbContext.QuoteScores
+            .AsNoTracking()
+            .Where(qs => quoteIds.Contains(qs.QuoteId))
+            .GroupBy(qs => qs.QuoteId)
+            .Select(g => new { QuoteId = g.Key, Score = g.Sum(qs => qs.Score) })
+            .ToDictionaryAsync(g => g.QuoteId, g => g.Score, ct);
+
+        List<int> userIds = [.. quotes.Select(q => q.UserId).Distinct()];
+        Dictionary<int, string> userMap = await dbContext.Users
+            .AsNoTracking()
+            .Where(u => userIds.Contains(u.Id))
+            .ToDictionaryAsync(u => u.Id, u => u.Username, ct);
+
+        var items = quotes.Select(q => new McpQuoteItem(
+            q.Id,
+            q.GuildId,
+            q.UserId,
+            userMap.GetValueOrDefault(q.UserId, "Unknown"),
+            q.Content ?? string.Empty,
+            q.InsertDate,
+            q.Approved,
+            q.Removed,
+            scoreMap.GetValueOrDefault(q.Id)
+        )).ToList();
+
+        return new McpQuotePage(page, totalPages, total, items.AsReadOnly());
+    }
+
+    /// <summary>
+    /// Gets details for a single quote.
+    /// </summary>
+    public async Task<McpQuoteDetail?> GetQuoteByIdAsync(int quoteId, CancellationToken ct = default)
+    {
+        Quote? quote = await dbContext.Quotes
+            .AsNoTracking()
+            .FirstOrDefaultAsync(q => q.Id == quoteId && !q.Removed, ct);
+
+        if (quote == null) return null;
+
+        int totalScore = await dbContext.QuoteScores
+            .AsNoTracking()
+            .Where(qs => qs.QuoteId == quote.Id)
+            .SumAsync(qs => (int?)qs.Score, ct) ?? 0;
+
+        string author = await dbContext.Users
+            .AsNoTracking()
+            .Where(u => u.Id == quote.UserId)
+            .Select(u => u.Username)
+            .FirstOrDefaultAsync(ct) ?? "Unknown";
+
+        return new McpQuoteDetail(
+            quote.Id,
+            quote.GuildId,
+            quote.Content ?? string.Empty,
+            quote.InsertDate,
+            quote.Approved,
+            quote.Removed,
+            totalScore,
+            author);
+    }
+
+    /// <summary>
+    /// Gets recent moderation/relevant log entries.
+    /// </summary>
+    public async Task<IReadOnlyList<McpModerationEntry>> GetRecentLogsAsync(
+        int limit = 20,
+        string? severity = null,
+        CancellationToken ct = default)
+    {
+        IQueryable<Log> query = dbContext.Logs.AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(severity))
+        {
+            if (Enum.TryParse<Discord.LogSeverity>(severity, true, out var parsedSeverity))
+                query = query.Where(l => l.Severity == (int)parsedSeverity);
+        }
+
+        if (limit < 1) limit = 20;
+        if (limit > 100) limit = 100;
+
+        var logs = await query
+            .OrderByDescending(l => l.InsertDate)
+            .Take(limit)
+            .ToListAsync(ct);
+
+        return logs.Select(l => new McpModerationEntry(
+            l.Id,
+            ((Discord.LogSeverity)l.Severity).ToString(),
+            l.Message,
+            l.InsertDate
+        )).ToList().AsReadOnly();
+    }
+
+    /// <summary>
+    /// Gets stock market summary with top gainers and losers.
+    /// </summary>
+    public async Task<McpStockSummary> GetStockSummaryAsync(int moverLimit = 5, CancellationToken ct = default)
+    {
+        int totalStocks = await dbContext.Stocks.AsNoTracking().CountAsync(ct);
+
+        var stocks = await dbContext.Stocks
+            .AsNoTracking()
+            .Where(s => s.Price > 0)
+            .ToListAsync(ct);
+
+        var gainers = stocks
+            .Where(s => s.DailyChangePercent > 0)
+            .OrderByDescending(s => s.DailyChangePercent)
+            .Take(moverLimit)
+            .Select(s => new McpStockItem(
+                s.Id,
+                s.EntityType.ToString(),
+                s.EntityId,
+                ResolveStockName(s),
+                Math.Round(s.Price, 2),
+                Math.Round(s.DailyChangePercent, 2)))
+            .ToList().AsReadOnly();
+
+        var losers = stocks
+            .Where(s => s.DailyChangePercent < 0)
+            .OrderBy(s => s.DailyChangePercent)
+            .Take(moverLimit)
+            .Select(s => new McpStockItem(
+                s.Id,
+                s.EntityType.ToString(),
+                s.EntityId,
+                ResolveStockName(s),
+                Math.Round(s.Price, 2),
+                Math.Round(s.DailyChangePercent, 2)))
+            .ToList().AsReadOnly();
+
+        return new McpStockSummary(totalStocks, gainers, losers);
+    }
+
+    /// <summary>
+    /// Gets activity leaderboard data.
+    /// </summary>
+    public async Task<IReadOnlyList<McpLeaderboardEntry>> GetLeaderboardAsync(
+        string metric = "xp",
+        int? guildId = null,
+        int days = 30,
+        int limit = 10,
+        CancellationToken ct = default)
+    {
+        if (limit < 1) limit = 10;
+        if (limit > 50) limit = 50;
+
+        DateTime since = DateTime.UtcNow.AddDays(-days);
+
+        IQueryable<UserActivity> activityQuery = dbContext.UserActivity
+            .AsNoTracking()
+            .Where(ua => ua.InsertDate >= since);
+
+        if (guildId.HasValue)
+            activityQuery = activityQuery.Where(ua => ua.GuildId == guildId.Value);
+
+        var raw = metric.ToLowerInvariant() switch
+        {
+            "messages" => await activityQuery
+                .GroupBy(ua => ua.UserId)
+                .Select(g => new { UserId = g.Key, Value = g.LongCount() })
+                .OrderByDescending(x => x.Value)
+                .Take(limit)
+                .ToListAsync(ct),
+            _ => await activityQuery
+                .GroupBy(ua => ua.UserId)
+                .Select(g => new { UserId = g.Key, Value = g.Sum(ua => (long)ua.XpGained) })
+                .OrderByDescending(x => x.Value)
+                .Take(limit)
+                .ToListAsync(ct)
+        };
+
+        if (raw.Count == 0)
+            return [];
+
+        List<int> userIds = [.. raw.Select(x => x.UserId)];
+        var users = await dbContext.Users
+            .AsNoTracking()
+            .Where(u => userIds.Contains(u.Id))
+            .ToDictionaryAsync(u => u.Id, ct);
+
+        var levels = await dbContext.UserLevels
+            .AsNoTracking()
+            .Where(ul => userIds.Contains(ul.UserId))
+            .GroupBy(ul => ul.UserId)
+            .Select(g => new { UserId = g.Key, MaxLevel = g.Max(ul => (int?)ul.Level) })
+            .ToDictionaryAsync(g => g.UserId, g => g.MaxLevel, ct);
+
+        return raw.Select((x, i) => new McpLeaderboardEntry(
+            i + 1,
+            x.UserId,
+            users.GetValueOrDefault(x.UserId)?.DiscordId ?? 0,
+            users.GetValueOrDefault(x.UserId)?.Username ?? "Unknown",
+            x.Value,
+            levels.GetValueOrDefault(x.UserId)
+        )).ToList().AsReadOnly();
+    }
+
+    private async Task<decimal> GetBotSettingDecimalAsync(string key, decimal defaultValue, CancellationToken ct)
+    {
+        BotSetting? setting = await dbContext.BotSettings
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Key == key, ct);
+
+        if (setting == null || string.IsNullOrWhiteSpace(setting.Value))
+            return defaultValue;
+
+        return decimal.TryParse(setting.Value, out decimal val) ? val : defaultValue;
+    }
+
+    private static string ResolveStockName(Stock stock)
+    {
+        // For stocks tied to entities, try to provide a meaningful name.
+        // If the entity isn't loaded, fall back to the stock id.
+        return $"Stock #{stock.Id} ({stock.EntityType})";
+    }
+}

--- a/Morpheus.Tests/McpServiceTests.cs
+++ b/Morpheus.Tests/McpServiceTests.cs
@@ -1,0 +1,419 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
+using Morpheus.MCP;
+
+namespace Morpheus.Tests;
+
+public class McpServiceTests
+{
+    [Fact]
+    public async Task GetUserStatsAsync_ReturnsUserStats_WhenUserExists()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        (Guild guild, User user) = await SeedBaseAsync(testDb.Db);
+
+        testDb.Db.UserLevels.Add(new UserLevels
+        {
+            GuildId = guild.Id,
+            UserId = user.Id,
+            TotalXp = 500,
+            UserMessageCount = 10,
+            Level = 3
+        });
+        testDb.Db.UserActivity.Add(new UserActivity
+        {
+            GuildId = guild.Id,
+            UserId = user.Id,
+            DiscordChannelId = 1,
+            DiscordMessageId = 2,
+            XpGained = 50,
+            MessageLength = 25,
+            InsertDate = DateTime.UtcNow.AddDays(-1)
+        });
+        await testDb.Db.SaveChangesAsync();
+
+        McpService service = CreateService(testDb.Db);
+
+        McpUserStats? stats = await service.GetUserStatsAsync(user.Id, null);
+
+        Assert.NotNull(stats);
+        Assert.Equal(user.Id, stats.Id);
+        Assert.Equal(user.DiscordId, stats.DiscordId);
+        Assert.Equal(user.Username, stats.Username);
+        Assert.Equal(1000m, stats.Balance);
+        Assert.Equal(10, stats.TotalMessages);
+        Assert.Equal(500, stats.TotalXp);
+        Assert.Equal(3, stats.Level);
+    }
+
+    [Fact]
+    public async Task GetUserStatsAsync_ReturnsNull_WhenUserNotFound()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        McpService service = CreateService(testDb.Db);
+
+        McpUserStats? stats = await service.GetUserStatsAsync(999, null);
+
+        Assert.Null(stats);
+    }
+
+    [Fact]
+    public async Task GetGuildInfoAsync_ReturnsGuildInfo_WhenGuildExists()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        (Guild guild, User user) = await SeedBaseAsync(testDb.Db);
+
+        testDb.Db.UserLevels.Add(new UserLevels
+        {
+            GuildId = guild.Id,
+            UserId = user.Id,
+            TotalXp = 200,
+            UserMessageCount = 5,
+            Level = 2
+        });
+        testDb.Db.Quotes.Add(new Quote
+        {
+            GuildId = guild.Id,
+            UserId = user.Id,
+            Content = "test quote",
+            Approved = true
+        });
+        await testDb.Db.SaveChangesAsync();
+
+        McpService service = CreateService(testDb.Db);
+
+        McpGuildInfo? info = await service.GetGuildInfoAsync(guild.Id, null);
+
+        Assert.NotNull(info);
+        Assert.Equal(guild.Id, info.Id);
+        Assert.Equal(guild.DiscordId, info.DiscordId);
+        Assert.Equal(guild.Name, info.Name);
+        Assert.Equal(guild.Prefix, info.Prefix);
+        Assert.Equal(1, info.TrackedUsers);
+        Assert.Equal(5, info.Messages);
+        Assert.Equal(200, info.Xp);
+        Assert.Equal(1, info.ApprovedQuotes);
+    }
+
+    [Fact]
+    public async Task GetEconomySummaryAsync_ReturnsSummary()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        await SeedBaseAsync(testDb.Db);
+
+        // Add a second user with balance
+        testDb.Db.Users.Add(new User
+        {
+            DiscordId = 999,
+            Username = "user2",
+            Balance = 500m
+        });
+        await testDb.Db.SaveChangesAsync();
+
+        McpService service = CreateService(testDb.Db);
+
+        McpEconomySummary summary = await service.GetEconomySummaryAsync();
+
+        Assert.Equal(2, summary.TotalUsers);
+        Assert.Equal(1500m, summary.TotalBalance);
+        Assert.Equal(750m, summary.AverageBalance);
+        Assert.Equal(0m, summary.UbiPoolSize);
+    }
+
+    [Fact]
+    public async Task GetActivityOverviewAsync_ReturnsOverview()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        (Guild guild, User user) = await SeedBaseAsync(testDb.Db);
+
+        testDb.Db.UserLevels.Add(new UserLevels
+        {
+            GuildId = guild.Id,
+            UserId = user.Id,
+            TotalXp = 300,
+            UserMessageCount = 7,
+            Level = 2
+        });
+        testDb.Db.UserActivity.Add(new UserActivity
+        {
+            GuildId = guild.Id,
+            UserId = user.Id,
+            DiscordChannelId = 1,
+            DiscordMessageId = 2,
+            XpGained = 100,
+            MessageLength = 50,
+            InsertDate = DateTime.UtcNow.AddHours(-1)
+        });
+        await testDb.Db.SaveChangesAsync();
+
+        McpService service = CreateService(testDb.Db);
+
+        McpActivityOverview overview = await service.GetActivityOverviewAsync();
+
+        Assert.Equal(7, overview.TotalMessages);
+        Assert.Equal(300, overview.TotalXp);
+        Assert.Equal(1, overview.ActiveUsersLast30Days);
+        Assert.Equal(1, overview.MessagesLast30Days);
+        Assert.Equal(100, overview.XpLast30Days);
+        Assert.Equal(1, overview.TotalServers);
+        Assert.Equal(1, overview.TotalKnownUsers);
+    }
+
+    [Fact]
+    public async Task GetGuildsAsync_ReturnsGuildList()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        await SeedBaseAsync(testDb.Db);
+
+        // Add a second guild
+        testDb.Db.Guilds.Add(new Guild
+        {
+            DiscordId = 222,
+            Name = "Server Two"
+        });
+        await testDb.Db.SaveChangesAsync();
+
+        McpService service = CreateService(testDb.Db);
+
+        IReadOnlyList<McpServerItem> guilds = await service.GetGuildsAsync();
+
+        Assert.Equal(2, guilds.Count);
+    }
+
+    [Fact]
+    public async Task GetUsersAsync_ReturnsPaginatedUsers()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        await SeedBaseAsync(testDb.Db);
+
+        McpService service = CreateService(testDb.Db);
+
+        IReadOnlyList<McpUserItem> users = await service.GetUsersAsync(page: 1, limit: 10);
+
+        Assert.Single(users);
+        Assert.Equal(1000m, users[0].Balance);
+    }
+
+    [Fact]
+    public async Task GetQuotesAsync_ReturnsQuotes()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        (Guild guild, User user) = await SeedBaseAsync(testDb.Db);
+
+        testDb.Db.Quotes.Add(new Quote
+        {
+            GuildId = guild.Id,
+            UserId = user.Id,
+            Content = "Hello world",
+            Approved = true
+        });
+        testDb.Db.Quotes.Add(new Quote
+        {
+            GuildId = guild.Id,
+            UserId = user.Id,
+            Content = "Second quote",
+            Approved = false
+        });
+        await testDb.Db.SaveChangesAsync();
+
+        McpService service = CreateService(testDb.Db);
+
+        // Get approved only
+        McpQuotePage page = await service.GetQuotesAsync(approvedOnly: true);
+
+        Assert.Equal(1, page.Total);
+        Assert.Single(page.Items);
+        Assert.Equal("Hello world", page.Items[0].Content);
+
+        // Get all (including pending)
+        McpQuotePage allPage = await service.GetQuotesAsync(approvedOnly: false);
+
+        Assert.Equal(2, allPage.Total);
+    }
+
+    [Fact]
+    public async Task GetQuoteByIdAsync_ReturnsQuote()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        (Guild guild, User user) = await SeedBaseAsync(testDb.Db);
+
+        Quote quote = new()
+        {
+            GuildId = guild.Id,
+            UserId = user.Id,
+            Content = "Test quote detail",
+            Approved = true
+        };
+        testDb.Db.Quotes.Add(quote);
+        await testDb.Db.SaveChangesAsync();
+
+        McpService service = CreateService(testDb.Db);
+
+        McpQuoteDetail? detail = await service.GetQuoteByIdAsync(quote.Id);
+
+        Assert.NotNull(detail);
+        Assert.Equal(quote.Id, detail.Id);
+        Assert.Equal("Test quote detail", detail.Content);
+        Assert.Equal(user.Username, detail.Author);
+    }
+
+    [Fact]
+    public async Task GetQuoteByIdAsync_ReturnsNull_WhenNotFound()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        McpService service = CreateService(testDb.Db);
+
+        McpQuoteDetail? detail = await service.GetQuoteByIdAsync(999);
+
+        Assert.Null(detail);
+    }
+
+    [Fact]
+    public async Task GetRecentLogsAsync_ReturnsLogs()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+
+        testDb.Db.Logs.Add(new Log { Message = "info log", Severity = (int)Discord.LogSeverity.Info, InsertDate = DateTime.UtcNow });
+        testDb.Db.Logs.Add(new Log { Message = "warning log", Severity = (int)Discord.LogSeverity.Warning, InsertDate = DateTime.UtcNow });
+        testDb.Db.Logs.Add(new Log { Message = "error log", Severity = (int)Discord.LogSeverity.Error, InsertDate = DateTime.UtcNow });
+        await testDb.Db.SaveChangesAsync();
+
+        McpService service = CreateService(testDb.Db);
+
+        IReadOnlyList<McpModerationEntry> logs = await service.GetRecentLogsAsync(limit: 10);
+
+        Assert.Equal(3, logs.Count);
+
+        // Filter by severity
+        IReadOnlyList<McpModerationEntry> errorLogs = await service.GetRecentLogsAsync(limit: 10, severity: "Error");
+        Assert.Single(errorLogs);
+        Assert.Equal("error log", errorLogs[0].Message);
+    }
+
+    [Fact]
+    public async Task GetLeaderboardAsync_ReturnsRankings()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        (Guild guild, User user) = await SeedBaseAsync(testDb.Db);
+
+        testDb.Db.UserActivity.Add(new UserActivity
+        {
+            GuildId = guild.Id,
+            UserId = user.Id,
+            DiscordChannelId = 1,
+            DiscordMessageId = 2,
+            XpGained = 100,
+            MessageLength = 25,
+            InsertDate = DateTime.UtcNow.AddHours(-1)
+        });
+        await testDb.Db.SaveChangesAsync();
+
+        McpService service = CreateService(testDb.Db);
+
+        IReadOnlyList<McpLeaderboardEntry> leaderboard = await service.GetLeaderboardAsync(
+            metric: "xp", guildId: guild.Id, days: 30, limit: 10);
+
+        Assert.Single(leaderboard);
+        Assert.Equal(1, leaderboard[0].Rank);
+        Assert.Equal(user.Id, leaderboard[0].UserId);
+        Assert.Equal(100, leaderboard[0].Value);
+    }
+
+    [Fact]
+    public async Task GetStockSummaryAsync_ReturnsSummary()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        (Guild _, User user) = await SeedBaseAsync(testDb.Db);
+
+        testDb.Db.Stocks.Add(new Stock
+        {
+            EntityType = Database.Enums.StockEntityType.User,
+            EntityId = user.Id,
+            Price = 120m,
+            PreviousPrice = 100m,
+            DailyChangePercent = 20m
+        });
+        testDb.Db.Stocks.Add(new Stock
+        {
+            EntityType = Database.Enums.StockEntityType.Guild,
+            EntityId = 2,
+            Price = 80m,
+            PreviousPrice = 100m,
+            DailyChangePercent = -20m
+        });
+        testDb.Db.Stocks.Add(new Stock
+        {
+            EntityType = Database.Enums.StockEntityType.Guild,
+            EntityId = 3,
+            Price = 50m,
+            PreviousPrice = 100m,
+            DailyChangePercent = -50m
+        });
+        await testDb.Db.SaveChangesAsync();
+
+        McpService service = CreateService(testDb.Db);
+
+        McpStockSummary summary = await service.GetStockSummaryAsync(moverLimit: 5);
+
+        Assert.Equal(3, summary.TotalStocks);
+        Assert.Single(summary.TopGainers);
+        Assert.Equal(2, summary.TopLosers.Count);
+        Assert.Equal(20m, summary.TopGainers[0].DailyChangePercent);
+        Assert.Equal(-50m, summary.TopLosers[0].DailyChangePercent);
+    }
+
+    // ── Test Infrastructure ──
+
+    private sealed class SqliteTestDb(SqliteConnection connection, DB db) : IAsyncDisposable
+    {
+        public DB Db { get; } = db;
+
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await connection.DisposeAsync();
+        }
+    }
+
+    private static async Task<SqliteTestDb> CreateSqliteDbAsync()
+    {
+        SqliteConnection connection = new("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+
+        DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        return new SqliteTestDb(connection, db);
+    }
+
+    private static async Task<(Guild Guild, User User)> SeedBaseAsync(DB db)
+    {
+        Guild guild = new()
+        {
+            DiscordId = 123,
+            Name = "Test Server",
+            Prefix = "m!"
+        };
+        db.Guilds.Add(guild);
+        await db.SaveChangesAsync();
+
+        User user = new()
+        {
+            DiscordId = 456,
+            Username = "TestUser",
+            Balance = 1000m
+        };
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+
+        return (guild, user);
+    }
+
+    private static McpService CreateService(DB db) => new(db);
+}

--- a/Program.cs
+++ b/Program.cs
@@ -3,11 +3,13 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Morpheus.Dashboard;
 using Morpheus.Extensions;
+using Morpheus.MCP;
 using Morpheus.Utilities;
 
 Env.Load(".env");
 
 DashboardApiOptions dashboardOptions = DashboardApiOptions.FromEnvironment();
+McpApiOptions mcpOptions = McpApiOptions.FromEnvironment();
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 builder.WebHost.UseUrls(dashboardOptions.Urls);
@@ -17,13 +19,15 @@ builder.Services
     .AddBotJobs()
     .AddBotHandlers()
     .AddBotDatabase()
-    .AddDashboardApi(dashboardOptions);
+    .AddDashboardApi(dashboardOptions)
+    .AddMcpApi(mcpOptions);
 
 WebApplication app = builder.Build();
 
 app.UseCors();
 app.UseOutputCache();
 app.MapDashboardApi();
+app.MapMcpApi();
 
 app.RunStartupMigrations();
 await app.StartBotAsync();


### PR DESCRIPTION
## Summary
- Added an HTTP MCP server exposing Morpheus bot data to AI agents
- 11 tools available: get_user_stats, get_guild_info, get_economy_summary, get_activity_overview, get_guilds, get_users, get_quotes, get_quote_by_id, get_recent_logs, get_stock_summary, get_leaderboard
- Supports configuration via environment variables

## Files
- `MCP/McpContracts.cs` — Request/response models and tool definitions
- `MCP/McpApiOptions.cs` — Configuration from environment
- `MCP/McpService.cs` — Business logic wrapping database queries
- `MCP/McpApiExtensions.cs` — DI registration + endpoint mapping
- `Morpheus.Tests/McpServiceTests.cs` — 11 unit tests
- `Program.cs` — Wired up AddMcpApi() and MapMcpApi()

## Verification
- `dotnet build` — 0 errors, 0 warnings
- `dotnet test` — 201 passed, 0 failed (11 new MCP tests + 190 existing)

## Risk
- Low — additive feature, no existing code modified

Closes #3

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.