### PR TITLE
fix: truncate reaction role button labels

### DIFF
--- a/Modules/ReactionRolesModule.cs
+++ b/Modules/ReactionRolesModule.cs
@@ -105,7 +105,7 @@ public class ReactionRolesModule : ModuleBase<SocketCommandContextExtended>
             for (int i = 0; i < roles.Count; i++)
             {
                 int row = i / 5;
-                componentBuilder.WithButton(roles[i].Name, customId: $"{CustomIdPrefix}{roles[i].Id}", style: ButtonStyle.Secondary, row: row);
+                componentBuilder.WithButton(FormatButtonLabel(roles[i].Name), customId: $"{CustomIdPrefix}{roles[i].Id}", style: ButtonStyle.Secondary, row: row);
             }
         }
         else
@@ -152,6 +152,18 @@ public class ReactionRolesModule : ModuleBase<SocketCommandContextExtended>
 
         dbContext.ReactionRoleItems.AddRange(items);
         await dbContext.SaveChangesAsync();
+    }
+
+    internal static string FormatButtonLabel(string roleName)
+    {
+        if (roleName.Length <= ButtonBuilder.MaxButtonLabelLength)
+            return roleName;
+
+        int prefixLength = ButtonBuilder.MaxButtonLabelLength - 1;
+        if (char.IsHighSurrogate(roleName[prefixLength - 1]) && char.IsLowSurrogate(roleName[prefixLength]))
+            prefixLength--;
+
+        return string.Concat(roleName.AsSpan(0, prefixLength), "…");
     }
 
     private async Task HandleReactionRoleInteraction(SocketInteraction interaction)

--- a/Morpheus.Tests/ReactionRolesModuleTests.cs
+++ b/Morpheus.Tests/ReactionRolesModuleTests.cs
@@ -1,0 +1,39 @@
+using Discord;
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class ReactionRolesModuleTests
+{
+    [Fact]
+    public void FormatButtonLabel_PreservesLabelsWithinDiscordLimit()
+    {
+        string roleName = new('a', ButtonBuilder.MaxButtonLabelLength);
+
+        string label = ReactionRolesModule.FormatButtonLabel(roleName);
+
+        Assert.Equal(roleName, label);
+    }
+
+    [Fact]
+    public void FormatButtonLabel_TruncatesLabelsBeyondDiscordLimit()
+    {
+        string roleName = new('a', ButtonBuilder.MaxButtonLabelLength + 1);
+
+        string label = ReactionRolesModule.FormatButtonLabel(roleName);
+
+        Assert.Equal(new string('a', ButtonBuilder.MaxButtonLabelLength - 1) + "…", label);
+        Assert.Equal(ButtonBuilder.MaxButtonLabelLength, label.Length);
+    }
+
+    [Fact]
+    public void FormatButtonLabel_DoesNotSplitSurrogatePairs()
+    {
+        string prefix = new('a', ButtonBuilder.MaxButtonLabelLength - 2);
+        string roleName = prefix + "😀bc";
+
+        string label = ReactionRolesModule.FormatButtonLabel(roleName);
+
+        Assert.Equal(prefix + "…", label);
+    }
+}


### PR DESCRIPTION
## Summary
- truncate reaction-role button labels to Discord’s supported 80-character limit
- preserve valid UTF-16 when truncation falls next to a surrogate pair
- add regression coverage for boundary, truncation, and surrogate-pair cases

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter "FullyQualifiedName~ReactionRolesModuleTests" --verbosity minimal` — passed: 3 tests
- `dotnet build` — passed with 2 existing NU1903 warnings for SQLitePCLRaw.lib.e_sqlite3 2.1.6
- `dotnet test --no-build --verbosity minimal` — passed: 191 tests
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: only overlong button labels are changed; role IDs and displayed role mentions remain unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
