### PR TITLE
fix: extend Pride activity through June

### DIFF
--- a/Jobs/BotActivityJob.cs
+++ b/Jobs/BotActivityJob.cs
@@ -84,7 +84,7 @@ public class BotActivityJob(LogsService logsService, DiscordSocketClient discord
         // Pride Day (June): Jun 1, 00:00 → Jul 1, 00:00
         new AnnualActivity(
             startMonth: 6, startDay: 1, startTime: TimeSpan.Zero,
-            endMonth:   6, endDay:   2,  endTime:   TimeSpan.Zero,
+            endMonth:   7, endDay:   1,  endTime:   TimeSpan.Zero,
             description: "chanting LGBTQ+ anthems 🌈"
         ),
 
@@ -253,20 +253,23 @@ public class BotActivityJob(LogsService logsService, DiscordSocketClient discord
 
     private static readonly Random _rng = new();
 
+    internal static string? GetAnnualActivityDescription(DateTime now) =>
+        Schedule.FirstOrDefault(activity => activity.IsActive(now))?.Description;
+
     public async Task Execute(IJobExecutionContext context)
     {
         DateTime now = DateTime.Now;
 
         // 3) Find an annual event matching today
-        AnnualActivity? evt = Schedule.FirstOrDefault(e => e.IsActive(now));
+        string? annualDescription = GetAnnualActivityDescription(now);
 
         ActivityType type;
         string description;
 
-        if (evt != null)
+        if (annualDescription != null)
         {
             // keep the annual description but ignore its stored type
-            description = evt.Description;
+            description = annualDescription;
         }
         else
         {

--- a/Morpheus.Tests/BotActivityJobTests.cs
+++ b/Morpheus.Tests/BotActivityJobTests.cs
@@ -1,0 +1,35 @@
+using Morpheus.Jobs;
+
+namespace Morpheus.Tests;
+
+public class BotActivityJobTests
+{
+    private const string PrideActivity = "chanting LGBTQ+ anthems 🌈";
+
+    [Theory]
+    [InlineData(6, 1, 0, 0)]
+    [InlineData(6, 15, 12, 30)]
+    [InlineData(6, 30, 23, 59)]
+    public void GetAnnualActivityDescription_DuringJune_ReturnsPrideActivity(
+        int month,
+        int day,
+        int hour,
+        int minute)
+    {
+        DateTime now = new(2026, month, day, hour, minute, 0);
+
+        string? result = BotActivityJob.GetAnnualActivityDescription(now);
+
+        Assert.Equal(PrideActivity, result);
+    }
+
+    [Fact]
+    public void GetAnnualActivityDescription_OnJulyFirst_ReturnsJulyActivity()
+    {
+        DateTime now = new(2026, 7, 1, 0, 0, 0);
+
+        string? result = BotActivityJob.GetAnnualActivityDescription(now);
+
+        Assert.Equal("vibing with summer vibes ☀️", result);
+    }
+}


### PR DESCRIPTION
## Summary
- fix the Pride bot activity window so it remains active for all of June, matching the existing schedule comment
- add regression coverage for dates throughout June and the exclusive July 1 boundary

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~BotActivityJobTests` — passed: 4 tests
- `dotnet build` — passed with 0 errors; existing NU1903 warnings for SQLitePCLRaw.lib.e_sqlite3 2.1.6
- `dotnet test` — passed: 230 tests
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: this changes one annual schedule end date and covers both the intended June window and July boundary with tests.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
