### PR TITLE
fix: stabilize activity leaderboard pagination

### DIFF
--- a/Morpheus.Tests/ActivityLeaderboardServiceTests.cs
+++ b/Morpheus.Tests/ActivityLeaderboardServiceTests.cs
@@ -108,4 +108,58 @@ public class ActivityLeaderboardServiceTests
         Assert.Equal(["[1] | active: Messages 5"], result.Page.Lines);
         Assert.Equal(1, result.Page.TotalPages);
     }
+
+    [Fact]
+    public async Task GetGuildXpLeaderboardAsync_OrdersTiesByUserIdAcrossPages()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        Guild guild = new() { DiscordId = 1, Name = "Test guild" };
+        List<User> users = [.. Enumerable.Range(1, 12)
+            .Select(index => new User { DiscordId = (ulong)index, Username = $"user{index:00}" })];
+        db.Add(guild);
+        db.AddRange(users);
+        await db.SaveChangesAsync();
+
+        db.UserLevels.AddRange(users.AsEnumerable().Reverse().Select(user => new UserLevels
+        {
+            UserId = user.Id,
+            GuildId = guild.Id,
+            TotalXp = 100
+        }));
+        await db.SaveChangesAsync();
+
+        ActivityLeaderboardService service = new(db);
+        ActivityLeaderboardQueryResult firstPage = await service.GetGuildXpLeaderboardAsync(
+            guild.Id,
+            guild.Name,
+            viewerUserId: null,
+            page: 1);
+        ActivityLeaderboardQueryResult secondPage = await service.GetGuildXpLeaderboardAsync(
+            guild.Id,
+            guild.Name,
+            viewerUserId: null,
+            page: 2);
+
+        Assert.True(firstPage.Success);
+        Assert.NotNull(firstPage.Page);
+        Assert.Equal(
+            users.Take(ActivityLeaderboardService.PageSize).Select((user, index) =>
+                $"[{index + 1}] | {user.Username}: Level 0 with 100 XP"),
+            firstPage.Page.Lines);
+
+        Assert.True(secondPage.Success);
+        Assert.NotNull(secondPage.Page);
+        Assert.Equal(
+            users.Skip(ActivityLeaderboardService.PageSize).Select((user, index) =>
+                $"[{ActivityLeaderboardService.PageSize + index + 1}] | {user.Username}: Level 0 with 100 XP"),
+            secondPage.Page.Lines);
+    }
 }

--- a/Services/ActivityLeaderboardService.cs
+++ b/Services/ActivityLeaderboardService.cs
@@ -18,7 +18,8 @@ public class ActivityLeaderboardService(DB dbContext)
         IQueryable<UserLevels> query = dbContext.UserLevels
             .AsNoTracking()
             .Where(ul => ul.GuildId == guildId)
-            .OrderByDescending(ul => ul.TotalXp);
+            .OrderByDescending(ul => ul.TotalXp)
+            .ThenBy(ul => ul.UserId);
 
         int totalUsers = await query.CountAsync();
         ActivityLeaderboardQueryResult? invalidPage = ValidatePage(page, totalUsers, "No level data found for this guild.");
@@ -53,7 +54,8 @@ public class ActivityLeaderboardService(DB dbContext)
         var query = baseQuery
             .GroupBy(ua => ua.UserId)
             .Select(g => new { UserId = g.Key, Value = (long)g.Sum(x => x.XpGained) })
-            .OrderByDescending(x => x.Value);
+            .OrderByDescending(x => x.Value)
+            .ThenBy(x => x.UserId);
 
         int totalUsers = await query.CountAsync();
         ActivityLeaderboardQueryResult? invalidPage = ValidatePage(page, totalUsers, $"No activity data found for the past {days} days.");
@@ -78,7 +80,8 @@ public class ActivityLeaderboardService(DB dbContext)
             .AsNoTracking()
             .GroupBy(ul => ul.UserId)
             .Select(g => new { UserId = g.Key, Value = (long)g.Sum(ul => ul.TotalXp) })
-            .OrderByDescending(x => x.Value);
+            .OrderByDescending(x => x.Value)
+            .ThenBy(x => x.UserId);
 
         int totalUsers = await query.CountAsync();
         ActivityLeaderboardQueryResult? invalidPage = ValidatePage(page, totalUsers, "No level data found globally.");
@@ -110,7 +113,8 @@ public class ActivityLeaderboardService(DB dbContext)
         var query = baseQuery
             .GroupBy(ua => ua.UserId)
             .Select(g => new { UserId = g.Key, Value = (long)g.Sum(x => x.XpGained) })
-            .OrderByDescending(x => x.Value);
+            .OrderByDescending(x => x.Value)
+            .ThenBy(x => x.UserId);
 
         int totalUsers = await query.CountAsync();
         ActivityLeaderboardQueryResult? invalidPage = ValidatePage(page, totalUsers, $"No activity data found globally for the past {days} days.");
@@ -138,7 +142,8 @@ public class ActivityLeaderboardService(DB dbContext)
         IQueryable<UserLevels> query = dbContext.UserLevels
             .AsNoTracking()
             .Where(ul => ul.GuildId == guildId && ul.UserMessageCount > 0)
-            .OrderByDescending(ul => ul.UserMessageCount);
+            .OrderByDescending(ul => ul.UserMessageCount)
+            .ThenBy(ul => ul.UserId);
 
         int totalUsers = await query.CountAsync();
         ActivityLeaderboardQueryResult? invalidPage = ValidatePage(page, totalUsers, "No message data found for this guild.");
@@ -173,7 +178,8 @@ public class ActivityLeaderboardService(DB dbContext)
         var query = baseQuery
             .GroupBy(ua => ua.UserId)
             .Select(g => new { UserId = g.Key, Value = g.Count() })
-            .OrderByDescending(x => x.Value);
+            .OrderByDescending(x => x.Value)
+            .ThenBy(x => x.UserId);
 
         int totalUsers = await query.CountAsync();
         ActivityLeaderboardQueryResult? invalidPage = ValidatePage(page, totalUsers, $"No message data found for the past {days} days.");
@@ -199,7 +205,8 @@ public class ActivityLeaderboardService(DB dbContext)
             .GroupBy(ul => ul.UserId)
             .Select(g => new { UserId = g.Key, Value = g.Sum(ul => ul.UserMessageCount) })
             .Where(x => x.Value > 0)
-            .OrderByDescending(x => x.Value);
+            .OrderByDescending(x => x.Value)
+            .ThenBy(x => x.UserId);
 
         int totalUsers = await query.CountAsync();
         ActivityLeaderboardQueryResult? invalidPage = ValidatePage(page, totalUsers, "No message data found globally.");
@@ -231,7 +238,8 @@ public class ActivityLeaderboardService(DB dbContext)
         var query = baseQuery
             .GroupBy(ua => ua.UserId)
             .Select(g => new { UserId = g.Key, Value = g.Count() })
-            .OrderByDescending(x => x.Value);
+            .OrderByDescending(x => x.Value)
+            .ThenBy(x => x.UserId);
 
         int totalUsers = await query.CountAsync();
         ActivityLeaderboardQueryResult? invalidPage = ValidatePage(page, totalUsers, $"No message data found globally for the past {days} days.");
@@ -259,7 +267,8 @@ public class ActivityLeaderboardService(DB dbContext)
         IQueryable<UserLevels> query = dbContext.UserLevels
             .AsNoTracking()
             .Where(ul => ul.GuildId == guildId && ul.UserMessageCount > 0)
-            .OrderByDescending(ul => ul.UserAverageMessageLength);
+            .OrderByDescending(ul => ul.UserAverageMessageLength)
+            .ThenBy(ul => ul.UserId);
 
         int totalUsers = await query.CountAsync();
         ActivityLeaderboardQueryResult? invalidPage = ValidatePage(page, totalUsers, "No message data found for this guild.");
@@ -301,7 +310,8 @@ public class ActivityLeaderboardService(DB dbContext)
             })
             .Where(x => x.SumCount > 0)
             .Select(x => new { x.UserId, AverageLength = x.SumLen / x.SumCount })
-            .OrderByDescending(x => x.AverageLength);
+            .OrderByDescending(x => x.AverageLength)
+            .ThenBy(x => x.UserId);
 
         int totalUsers = await query.CountAsync();
         ActivityLeaderboardQueryResult? invalidPage = ValidatePage(page, totalUsers, "No message data found globally.");


### PR DESCRIPTION
## Summary
- add a stable user-ID tie-breaker to every paginated activity leaderboard query
- add a regression test covering equal-XP users split across page boundaries

## Verification
- `dotnet build` — passed (0 errors; existing NU1903 advisory warning)
- `dotnet test` — passed (227 tests)
- `git diff --check` — passed

## Risk
- Low: only ordering among users tied on the displayed metric changes; no schema or command changes.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
