### PR TITLE
fix: accept uppercase dice notation

### DIFF
--- a/Modules/MiscModule.cs
+++ b/Modules/MiscModule.cs
@@ -177,14 +177,7 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
     [RateLimit(3, 10)]
     public async Task RollDice([Remainder] string input = "1d6")
     {
-        if (input.AsSpan().Count('d') != 1)
-        {
-            await ReplyAsync("Invalid input. Please provide input in the format of `xdy` where x is the number of dice and y is the number of sides.");
-            return;
-        }
-
-        string[] parts = input.Split('d');
-        if (parts.Length != 2 || !int.TryParse(parts[0], out int count) || !int.TryParse(parts[1], out int sides) || count < 1 || sides < 2)
+        if (!TryParseDiceInput(input, out int count, out int sides))
         {
             await ReplyAsync("Invalid input. Please provide input in the format of `xdy` where x is the number of dice and y is the number of sides.");
             return;
@@ -219,6 +212,22 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
             sb.Append($"\n\nTotal: {total}");
 
         await ReplyAsync(sb.ToString());
+    }
+
+    internal static bool TryParseDiceInput(string input, out int count, out int sides)
+    {
+        ReadOnlySpan<char> inputSpan = input.AsSpan();
+        int separatorIndex = inputSpan.IndexOfAny('d', 'D');
+
+        count = 0;
+        sides = 0;
+
+        return separatorIndex >= 0
+            && inputSpan[(separatorIndex + 1)..].IndexOfAny('d', 'D') < 0
+            && int.TryParse(inputSpan[..separatorIndex], out count)
+            && int.TryParse(inputSpan[(separatorIndex + 1)..], out sides)
+            && count >= 1
+            && sides >= 2;
     }
 
     [Name("Choose")]

--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -42,4 +42,27 @@ public class MiscModuleTests
 
         Assert.Equal(int.MaxValue, result);
     }
+
+    [Theory]
+    [InlineData("1d6", 1, 6)]
+    [InlineData("2D20", 2, 20)]
+    public void TryParseDiceInput_AcceptsEitherSeparatorCase(string input, int expectedCount, int expectedSides)
+    {
+        bool parsed = MiscModule.TryParseDiceInput(input, out int count, out int sides);
+
+        Assert.True(parsed);
+        Assert.Equal(expectedCount, count);
+        Assert.Equal(expectedSides, sides);
+    }
+
+    [Theory]
+    [InlineData("1d6D8")]
+    [InlineData("1D")]
+    [InlineData("D6")]
+    [InlineData("0D6")]
+    [InlineData("1D1")]
+    public void TryParseDiceInput_RejectsMalformedOrOutOfRangeInput(string input)
+    {
+        Assert.False(MiscModule.TryParseDiceInput(input, out _, out _));
+    }
 }


### PR DESCRIPTION
## Summary
- accept both lowercase `d` and uppercase `D` in dice notation (for example, `2D20`)
- extract dice input parsing into a testable helper while preserving existing bounds and validation
- add regression coverage for both separator cases and malformed inputs

## Verification
- `dotnet build` — passed (0 errors; existing NU1903 SQLite package warnings)
- `dotnet test` — passed (233 tests)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~MiscModuleTests` — passed (16 tests)
- `git diff --check` — passed

## Risk
- Low: the change is limited to dice input parsing and retains the existing minimum/maximum validation.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
