### PR TITLE
fix: clean reminder duration separators

### DIFF
--- a/Modules/UtilityModule.cs
+++ b/Modules/UtilityModule.cs
@@ -13,6 +13,17 @@ namespace Morpheus.Modules;
 public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtended>
 {
     private static readonly HttpClient httpClient = new();
+    private const string ReminderDurationTokenPatternText =
+        "(\\d+)\\s*(years?|yrs?|y|months?|mos?|mo|weeks?|w|days?|d|hours?|hrs?|h|minutes?|mins?|m|seconds?|secs?|s)\\b";
+    private static readonly Regex ReminderDurationTokenPattern = new(
+        ReminderDurationTokenPatternText,
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex ReminderDurationSequencePattern = new(
+        $"{ReminderDurationTokenPatternText}(?:\\s*(?:(?:,\\s*)?and|[,;])\\s*{ReminderDurationTokenPatternText})*",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex LeadingReminderSeparatorPattern = new(
+        "^[,;:\\-]\\s*",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     // DB is provided by primary-constructor style parameter
     // (accessible as 'dbContext' directly)
 
@@ -102,8 +113,7 @@ public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtend
         // No separate ping field — users can include mentions in the reminder text if desired.
 
         // Find all number+unit tokens
-        var tokenPattern = new Regex("(\\d+)\\s*(years?|yrs?|y|months?|mos?|mo|weeks?|w|days?|d|hours?|hrs?|h|minutes?|mins?|m|seconds?|secs?|s)\\b", RegexOptions.IgnoreCase);
-        var matches = tokenPattern.Matches(input);
+        MatchCollection matches = ReminderDurationTokenPattern.Matches(input);
 
         if (matches.Count == 0)
         {
@@ -177,10 +187,8 @@ public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtend
         }
 
         // Remove the duration tokens from input to get optional text
-        input = tokenPattern.Replace(input, "").Trim();
-
-        // After removing tokens and mention, remaining text is the reminder text
-        string? text = string.IsNullOrWhiteSpace(input) ? null : input.Trim();
+        // After removing duration tokens and their leading separators, the remainder is the reminder text.
+        string? text = ExtractReminderText(input);
 
         // Require some text for the reminder
         if (string.IsNullOrWhiteSpace(text))
@@ -206,6 +214,16 @@ public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtend
         await dbContext.SaveChangesAsync();
 
         await ReplyAsync($"Reminder scheduled for {due:yyyy-MM-dd HH:mm:ss} UTC.");
+    }
+
+    internal static string? ExtractReminderText(string input)
+    {
+        string text = ReminderDurationSequencePattern.Replace(input, "").Trim();
+
+        while (LeadingReminderSeparatorPattern.IsMatch(text))
+            text = LeadingReminderSeparatorPattern.Replace(text, "").TrimStart();
+
+        return string.IsNullOrWhiteSpace(text) ? null : text;
     }
 
 }

--- a/Morpheus.Tests/UtilityModuleTests.cs
+++ b/Morpheus.Tests/UtilityModuleTests.cs
@@ -21,4 +21,18 @@ public class UtilityModuleTests
         Assert.True(found);
         Assert.Equal(42UL, messageId);
     }
+
+    [Theory]
+    [InlineData("5 days and 3 hours @User Take a break", "@User Take a break")]
+    [InlineData("5 days, 3 hours: Take a break", "Take a break")]
+    [InlineData("5 days - Buy milk and eggs", "Buy milk and eggs")]
+    [InlineData("5 days Remember Alice and Bob", "Remember Alice and Bob")]
+    [InlineData("5 days and remember to buy milk", "and remember to buy milk")]
+    [InlineData("5 days and 3 hours and remember to call Alice", "and remember to call Alice")]
+    [InlineData("5 days, and remember to buy milk", "and remember to buy milk")]
+    [InlineData("5 days and 3 hours", null)]
+    public void ExtractReminderText_RemovesDurationSeparators(string input, string? expected)
+    {
+        Assert.Equal(expected, UtilityModule.ExtractReminderText(input));
+    }
 }


### PR DESCRIPTION
## Summary
- remove conjunctions and punctuation that only separate reminder duration tokens
- preserve reminder prose that legitimately starts with "and"
- add regression coverage for documented multi-part duration examples and prose edge cases

## Verification
- `dotnet build` — passed (0 errors; existing NU1903 warning for SQLitePCLRaw.lib.e_sqlite3 2.1.6)
- `dotnet test --no-build --verbosity minimal` — passed (234 tests)
- `git diff --check` — passed

## Risk
- Low: the change is limited to extracting reminder text after the existing duration parser runs.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
