### PR TITLE
fix: preserve RSS history across feed rollover

### DIFF
--- a/Jobs/RssFeedJob.cs
+++ b/Jobs/RssFeedJob.cs
@@ -44,7 +44,9 @@ public class RssFeedJob(DB db, RssFeedService rssFeed, DiscordWebhookService dis
 
             // If nothing from this feed has ever been seen, this is an initial run: mark
             // everything seen and only post the latest entry to avoid backfilling history.
-            bool initialSeed = !entries.Any(e => seen.Contains(e.EntryId));
+            // Check all history for the feed because older seen entries may have rolled out of
+            // the feed's current response.
+            bool initialSeed = !await HasFeedHistoryAsync(db, feedUrl);
             if (initialSeed)
             {
                 RssFeedService.FeedEntry latest = entries.OrderByDescending(e => e.Published).First();
@@ -96,6 +98,9 @@ public class RssFeedJob(DB db, RssFeedService rssFeed, DiscordWebhookService dis
 
         return allSucceeded;
     }
+
+    internal static Task<bool> HasFeedHistoryAsync(DB db, string feedUrl) =>
+        db.RssSeenEntries.AnyAsync(entry => entry.FeedUrl == feedUrl);
 
     private async Task<bool> SendAsync(RssSubscription sub, string content)
     {

--- a/Morpheus.Tests/RssFeedJobTests.cs
+++ b/Morpheus.Tests/RssFeedJobTests.cs
@@ -1,3 +1,6 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
 using Morpheus.Database.Models;
 using Morpheus.Jobs;
 using Morpheus.Services;
@@ -6,6 +9,28 @@ namespace Morpheus.Tests;
 
 public class RssFeedJobTests
 {
+    [Fact]
+    public async Task HasFeedHistoryAsync_WhenOlderEntryRolledOutOfFeed_ReturnsTrue()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+        db.RssSeenEntries.Add(new RssSeenEntry
+        {
+            FeedUrl = "https://example.com/feed",
+            EntryId = "entry-that-is-no-longer-in-the-feed"
+        });
+        await db.SaveChangesAsync();
+
+        bool hasHistory = await RssFeedJob.HasFeedHistoryAsync(db, "https://example.com/feed");
+
+        Assert.True(hasHistory);
+    }
+
     [Fact]
     public async Task DispatchAsync_WhenOneDeliveryFails_ReportsFailureAndAttemptsEverySubscriber()
     {


### PR DESCRIPTION
## Summary
- detect existing RSS feed history independently of the entries in the current response
- prevent rotating feeds from being mistaken for first-time subscriptions and dropping all but the latest new item
- add a SQLite regression test for history that has rolled out of the current feed

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~RssFeedJobTests` — passed: 4/4 tests
- `dotnet build` — passed: 0 errors; 2 existing NU1903 warnings for SQLitePCLRaw.lib.e_sqlite3 2.1.6
- `dotnet test` — passed: 227/227 tests
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change adds one indexed existence query per subscribed feed and leaves initial-feed backfill behavior unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
