### PR TITLE
fix: preserve RSS query commas

### DIFF
--- a/Morpheus.Tests/SubscriptionInputParserTests.cs
+++ b/Morpheus.Tests/SubscriptionInputParserTests.cs
@@ -44,6 +44,54 @@ public class SubscriptionInputParserTests
         Assert.All(parsed, source => Assert.Null(source.DisplayName));
     }
 
+    [Theory]
+    [InlineData("https://example.com/feed.xml?tags=release,stable", null)]
+    [InlineData("https://example.com/feed.xml?tags=release,stable Example feed", "Example feed")]
+    public void ParseRssSources_PreservesQueryCommasForSingleFeed(string input, string? expectedDisplayName)
+    {
+        SubscriptionInputParser.RssSource parsed = Assert.Single(SubscriptionInputParser.ParseRssSources(input));
+
+        Assert.Equal("https://example.com/feed.xml?tags=release,stable", parsed.Url);
+        Assert.Equal(expectedDisplayName, parsed.DisplayName);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/feed.xml?tags=release,stable")]
+    [InlineData("https://example.com/feed.xml?tags=release,stable Example feed")]
+    public void ParseRssSources_PreservesQueryCommasInMultilineInput(string firstSource)
+    {
+        IReadOnlyList<SubscriptionInputParser.RssSource> parsed = SubscriptionInputParser.ParseRssSources(
+            $"{firstSource}\nhttps://example.org/atom.xml");
+
+        Assert.Equal(
+            ["https://example.com/feed.xml?tags=release,stable", "https://example.org/atom.xml"],
+            parsed.Select(source => source.Url));
+    }
+
+    [Fact]
+    public void ParseRssSources_PreservesQueryCommasInSpaceSeparatedUrls()
+    {
+        IReadOnlyList<SubscriptionInputParser.RssSource> parsed = SubscriptionInputParser.ParseRssSources(
+            "https://example.com/feed.xml?tags=release,stable https://example.org/atom.xml");
+
+        Assert.Equal(
+            ["https://example.com/feed.xml?tags=release,stable", "https://example.org/atom.xml"],
+            parsed.Select(source => source.Url));
+    }
+
+    [Theory]
+    [InlineData("https://example.com/feed.xml,https://example.org/atom.xml")]
+    [InlineData("https://example.com/feed.xml , https://example.org/atom.xml")]
+    [InlineData("https://example.com/feed.xml;https://example.org/atom.xml")]
+    public void ParseRssSources_AcceptsPunctuationSeparatedUrls(string input)
+    {
+        IReadOnlyList<SubscriptionInputParser.RssSource> parsed = SubscriptionInputParser.ParseRssSources(input);
+
+        Assert.Equal(
+            ["https://example.com/feed.xml", "https://example.org/atom.xml"],
+            parsed.Select(source => source.Url));
+    }
+
     [Fact]
     public void ParseRssSources_AcceptsOneFeedPerLineWithOptionalNames()
     {

--- a/Utilities/SubscriptionInputParser.cs
+++ b/Utilities/SubscriptionInputParser.cs
@@ -40,7 +40,7 @@ internal static partial class SubscriptionInputParser
 
         if (lines.Length == 1)
         {
-            string[] tokens = SplitTokens(lines[0]).ToArray();
+            string[] tokens = SplitRssTokens(lines[0]).ToArray();
             string[] urls = tokens.Where(IsHttpUrl).ToArray();
             if (urls.Length > 1)
                 return urls
@@ -56,7 +56,10 @@ internal static partial class SubscriptionInputParser
             if (separatorIndex < 0)
             {
                 int commaIndex = line.IndexOf(',');
-                if (commaIndex > 0 && IsHttpUrl(line[..commaIndex].Trim()))
+                int queryIndex = line.IndexOf('?');
+                if (commaIndex > 0 &&
+                    (queryIndex < 0 || commaIndex < queryIndex) &&
+                    IsHttpUrl(line[..commaIndex].Trim()))
                     separatorIndex = commaIndex;
             }
 
@@ -100,6 +103,10 @@ internal static partial class SubscriptionInputParser
     private static IEnumerable<string> SplitTokens(string input) => input
         .Split([' ', '\t', '\r', '\n', ',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
+    private static IEnumerable<string> SplitRssTokens(string input) => RssUrlSeparatorRegex()
+        .Split(input)
+        .Where(token => !string.IsNullOrWhiteSpace(token));
+
     private static IReadOnlyList<string> Deduplicate(IEnumerable<string> values) => values
         .Distinct(StringComparer.OrdinalIgnoreCase)
         .ToArray();
@@ -112,4 +119,7 @@ internal static partial class SubscriptionInputParser
 
     [GeneratedRegex("^<#(\\d+)>$")]
     private static partial Regex ChannelMentionRegex();
+
+    [GeneratedRegex(@"(?:\s*[,;]\s*|\s+)(?=https?://)", RegexOptions.IgnoreCase)]
+    private static partial Regex RssUrlSeparatorRegex();
 }


### PR DESCRIPTION
## Summary
- preserve commas inside RSS feed query values instead of treating them as display-name separators
- keep whitespace-, comma-, and semicolon-separated bulk URL input working
- add regression coverage for single-feed, multiline, and bulk input forms

## Verification
- `dotnet build` — passed with 0 errors; existing NU1903 advisory warning remains for SQLitePCLRaw.lib.e_sqlite3 2.1.6
- `dotnet test --no-build` — passed, 234 tests
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change is isolated to RSS subscription input tokenization and is covered by focused parser tests.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
