### PR TITLE
fix: propagate webhook cancellation

### DIFF
--- a/Morpheus.Tests/DiscordWebhookServiceTests.cs
+++ b/Morpheus.Tests/DiscordWebhookServiceTests.cs
@@ -1,0 +1,28 @@
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class DiscordWebhookServiceTests
+{
+    [Fact]
+    public async Task SendAsync_WhenCallerCancels_PropagatesCancellation()
+    {
+        DiscordWebhookService service = new(new LogsService(new LogQueue()));
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.SendAsync(123, "token", "content", "username", null, cts.Token));
+    }
+
+    [Fact]
+    public async Task CheckExistsAsync_WhenCallerCancels_PropagatesCancellation()
+    {
+        DiscordWebhookService service = new(new LogsService(new LogQueue()));
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.CheckExistsAsync(123, "token", cts.Token));
+    }
+}

--- a/Services/DiscordWebhookService.cs
+++ b/Services/DiscordWebhookService.cs
@@ -59,6 +59,10 @@ public class DiscordWebhookService(LogsService logsService)
                 logsService.Log($"Webhook execute failed ({webhookId}): {(int)resp.StatusCode} {resp.StatusCode} - {respBody}", LogSeverity.Warning);
                 return false;
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 logsService.Log($"Webhook execute exception ({webhookId}): {ex.Message}", LogSeverity.Warning);
@@ -91,6 +95,10 @@ public class DiscordWebhookService(LogsService logsService)
                 return false;
 
             return null;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- propagate caller-requested cancellation from Discord webhook send and existence checks instead of converting it into delivery/health failures
- add regression tests for both webhook operations

## Verification
- `dotnet test --no-restore --filter FullyQualifiedName~DiscordWebhookServiceTests` — passed (2 tests)
- `dotnet build` — passed with the existing NU1903 advisory warning for SQLitePCLRaw.lib.e_sqlite3 2.1.6
- `dotnet test --no-build` — passed (228 tests)
- `git diff --cached --check` — passed before commit

## Risk
- Low: only caller-requested cancellation is rethrown; HTTP timeouts continue through the existing failure handling because the caller token is not canceled.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
