### PR TITLE
fix: validate Twitch subscription URL hosts

### DIFF
--- a/Modules/SubscriptionsModule.cs
+++ b/Modules/SubscriptionsModule.cs
@@ -933,10 +933,20 @@ public class SubscriptionsModule : ModuleBase<SocketCommandContextExtended>
     {
         input = input.Trim();
 
-        // Accept a full channel URL like https://twitch.tv/name or twitch.tv/name
-        int idx = input.IndexOf("twitch.tv/", StringComparison.OrdinalIgnoreCase);
-        if (idx >= 0)
-            input = input[(idx + "twitch.tv/".Length)..];
+        // Accept a full channel URL like https://twitch.tv/name or twitch.tv/name,
+        // but do not mistake an unrelated host or path containing "twitch.tv/" for Twitch.
+        bool containsScheme = input.Contains("://", StringComparison.Ordinal);
+        bool containsTwitchPath = input.Contains("twitch.tv/", StringComparison.OrdinalIgnoreCase);
+        if (containsScheme || containsTwitchPath)
+        {
+            string url = containsScheme ? input : $"https://{input}";
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri)
+                || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+                || !IsTwitchHost(uri.Host))
+                return string.Empty;
+
+            input = uri.AbsolutePath;
+        }
 
         // Strip any leading @, trailing slash, query, or fragment, and lowercase.
         input = input.TrimStart('@').Trim('/');
@@ -944,8 +954,16 @@ public class SubscriptionsModule : ModuleBase<SocketCommandContextExtended>
         if (delimiter >= 0)
             input = input[..delimiter];
 
-        return input.ToLowerInvariant();
+        return IsValidTwitchLogin(input) ? input.ToLowerInvariant() : string.Empty;
     }
+
+    private static bool IsTwitchHost(string host) =>
+        host.Equals("twitch.tv", StringComparison.OrdinalIgnoreCase)
+        || host.EndsWith(".twitch.tv", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsValidTwitchLogin(string login) =>
+        login.Length is > 0 and <= 25
+        && login.All(c => c is >= 'a' and <= 'z' or >= 'A' and <= 'Z' or >= '0' and <= '9' or '_');
 
     internal static string EscapeLikePattern(string value) => value
         .Replace("\\", "\\\\", StringComparison.Ordinal)

--- a/Morpheus.Tests/SubscriptionsModuleTests.cs
+++ b/Morpheus.Tests/SubscriptionsModuleTests.cs
@@ -12,6 +12,28 @@ public class SubscriptionsModuleTests
         Assert.Equal("streamer", login);
     }
 
+    [Theory]
+    [InlineData("@Streamer", "streamer")]
+    [InlineData("twitch.tv/Streamer", "streamer")]
+    [InlineData("www.twitch.tv/Streamer/videos", "streamer")]
+    [InlineData("https://m.twitch.tv/Streamer?referrer=raid", "streamer")]
+    public void ExtractTwitchLogin_AcceptsHandlesAndTwitchUrls(string input, string expected)
+    {
+        Assert.Equal(expected, SubscriptionsModule.ExtractTwitchLogin(input));
+    }
+
+    [Theory]
+    [InlineData("https://example.com/twitch.tv/Streamer")]
+    [InlineData("https://not-twitch.tv/Streamer")]
+    [InlineData("example.com/twitch.tv/Streamer")]
+    [InlineData("https://twitch.tv.evil.example/Streamer")]
+    [InlineData("example.com/Streamer")]
+    [InlineData("twitch.tv.evil.example/Streamer")]
+    public void ExtractTwitchLogin_RejectsNonTwitchUrls(string input)
+    {
+        Assert.Empty(SubscriptionsModule.ExtractTwitchLogin(input));
+    }
+
     [Fact]
     public void EscapeLikePattern_EscapesWildcardsAndEscapeCharacters()
     {


### PR DESCRIPTION
## Summary
- parse Twitch channel URLs structurally instead of matching `twitch.tv/` anywhere in the input
- reject non-Twitch hosts and invalid Twitch login characters before subscription lookups
- cover handles, Twitch subdomains, query/fragment paths, and deceptive host inputs with regression tests

## Verification
- `dotnet build` — passed: 0 errors (existing NU1903 package advisory warning remains)
- `dotnet test` — passed: 236 tests, 0 failed, 0 skipped
- `git diff --check upstream/develop...HEAD` — passed
- `dotnet format Morpheus.sln --verify-no-changes --no-restore` — failed: repository-wide pre-existing whitespace, line-ending, and import-order diagnostics, including many unrelated files

## Risk
- Low: change is limited to Twitch subscription input normalization and rejects only malformed logins or URLs whose parsed host is not Twitch.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
