### PR TITLE
fix: retry temp unbans when guild is unavailable

### DIFF
--- a/Jobs/TemporaryBansJob.cs
+++ b/Jobs/TemporaryBansJob.cs
@@ -32,8 +32,7 @@ public class TemporaryBansJob(LogsService logsService, DB db, DiscordSocketClien
                 var guild = discordClient.GetGuild(ban.GuildId);
                 if (guild == null)
                 {
-                    Log($"Guild {ban.GuildId} not found for temp ban {ban.Id}. Marking as unbanned.", LogSeverity.Warning);
-                    ban.UnbannedAt = now;
+                    Log($"Guild {ban.GuildId} not found for temp ban {ban.Id}. Will retry later.", LogSeverity.Warning);
                     continue;
                 }
 

--- a/Morpheus.Tests/TemporaryBansJobTests.cs
+++ b/Morpheus.Tests/TemporaryBansJobTests.cs
@@ -1,0 +1,42 @@
+using Discord.WebSocket;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
+using Morpheus.Jobs;
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class TemporaryBansJobTests
+{
+    [Fact]
+    public async Task Execute_WhenGuildIsUnavailable_LeavesBanPendingForRetry()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        TemporaryBan ban = new()
+        {
+            GuildId = 1,
+            UserId = 2,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(-1)
+        };
+        db.TemporaryBans.Add(ban);
+        await db.SaveChangesAsync();
+
+        using DiscordSocketClient discordClient = new();
+        TemporaryBansJob job = new(new LogsService(new LogQueue()), db, discordClient);
+
+        await job.Execute(null!);
+        db.ChangeTracker.Clear();
+
+        TemporaryBan persistedBan = await db.TemporaryBans.SingleAsync();
+        Assert.Null(persistedBan.UnbannedAt);
+    }
+}


### PR DESCRIPTION
## Summary
- keep expired temporary bans pending when their guild is unavailable in the Discord client cache
- retry the unban on a later job run instead of recording an unban that never occurred
- add a SQLite-backed regression test for the missing-guild path

## Verification
- `dotnet build` — passed (227-test solution built; existing NU1903 advisory warning for SQLitePCLRaw.lib.e_sqlite3 2.1.6)
- `dotnet test --no-build` — passed (227 tests)
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change only retains pending state when no guild can be resolved; successful unbans and exception retries are unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
