### PR TITLE
fix: normalize RSS publication dates to UTC

### DIFF
--- a/Morpheus.Tests/RssFeedServiceTests.cs
+++ b/Morpheus.Tests/RssFeedServiceTests.cs
@@ -4,6 +4,32 @@ namespace Morpheus.Tests;
 
 public class RssFeedServiceTests
 {
+    [Theory]
+    [InlineData("Wed, 30 Jul 2025 12:00:00 +0200", 2025, 7, 30, 10, 0, 0)]
+    [InlineData("2025-07-30T12:00:00+02:00", 2025, 7, 30, 10, 0, 0)]
+    [InlineData("Tue, 01 Jul 2025 00:30:00 -0200", 2025, 7, 1, 2, 30, 0)]
+    [InlineData("Wed, 30 Jul 2025 10:00:00 GMT", 2025, 7, 30, 10, 0, 0)]
+    public void ParsePublished_NormalizesFeedDatesToUtc(
+        string value,
+        int year,
+        int month,
+        int day,
+        int hour,
+        int minute,
+        int second)
+    {
+        DateTime published = RssFeedService.ParsePublished(value);
+
+        Assert.Equal(new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc), published);
+        Assert.Equal(DateTimeKind.Utc, published.Kind);
+    }
+
+    [Fact]
+    public void ParsePublished_WhenValueIsInvalid_ReturnsMinimumValue()
+    {
+        Assert.Equal(DateTime.MinValue, RssFeedService.ParsePublished("not-a-date"));
+    }
+
     [Fact]
     public async Task FetchAsync_WhenCallerCancels_PropagatesCancellation()
     {

--- a/Services/RssFeedService.cs
+++ b/Services/RssFeedService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Xml.Linq;
 using Discord;
 
@@ -47,7 +48,7 @@ public class RssFeedService(LogsService logsService)
                     string id = e.Element(Atom + "id")?.Value ?? link;
                     string title = e.Element(Atom + "title")?.Value ?? string.Empty;
                     string pubRaw = e.Element(Atom + "published")?.Value ?? e.Element(Atom + "updated")?.Value ?? string.Empty;
-                    DateTime.TryParse(pubRaw, out DateTime published);
+                    DateTime published = ParsePublished(pubRaw);
 
                     if (!string.IsNullOrWhiteSpace(id))
                         entries.Add(new FeedEntry(id, title, link, published));
@@ -63,7 +64,7 @@ public class RssFeedService(LogsService logsService)
                     string id = it.Element("guid")?.Value ?? it.Element("id")?.Value ?? link;
                     string title = it.Element("title")?.Value ?? string.Empty;
                     string pubRaw = it.Element("pubDate")?.Value ?? it.Element("published")?.Value ?? string.Empty;
-                    DateTime.TryParse(pubRaw, out DateTime published);
+                    DateTime published = ParsePublished(pubRaw);
 
                     if (!string.IsNullOrWhiteSpace(id))
                         entries.Add(new FeedEntry(id, title, link, published));
@@ -95,4 +96,13 @@ public class RssFeedService(LogsService logsService)
             return (null, null, []);
         }
     }
+
+    internal static DateTime ParsePublished(string value) =>
+        DateTime.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out DateTime published)
+            ? published
+            : DateTime.MinValue;
 }


### PR DESCRIPTION
## Summary
- parse RSS and Atom publication timestamps with invariant culture rules
- normalize explicit offsets and offset-less timestamps to UTC before feed ordering
- add regression coverage for RFC 822, ISO 8601, positive and negative offsets, GMT, and invalid values

## Verification
- `dotnet test --no-restore --nologo --filter 'FullyQualifiedName~RssFeedServiceTests'` — passed: 6 tests
- `dotnet build --no-restore --nologo` — passed with the existing SQLitePCLRaw vulnerability advisory warning
- `dotnet test --no-build --no-restore --nologo` — passed: 231 tests
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change is limited to feed timestamp parsing, retains `DateTime.MinValue` for invalid dates, and adds focused regression tests.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
