### PR TITLE
fix: ignore blank choose options

### DIFF
--- a/Modules/MiscModule.cs
+++ b/Modules/MiscModule.cs
@@ -228,7 +228,7 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
     [RateLimit(3, 10)]
     public async Task Choose([Remainder] string options)
     {
-        string[] parts = options.Split('\n');
+        string[] parts = ParseChoices(options);
         if (parts.Length < 2)
         {
             await ReplyAsync("Please provide at least two options, one on each line.");
@@ -236,8 +236,15 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
         }
 
         Random random = new();
-        string choice = parts[random.Next(parts.Length)].Trim();
+        string choice = parts[random.Next(parts.Length)];
         await ReplyAsync($"Hmmm I choose: {choice}");
+    }
+
+    internal static string[] ParseChoices(string options)
+    {
+        return options.Split(
+            '\n',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
 
     [Name("Random Number")]

--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -36,6 +36,22 @@ public class MiscModuleTests
     }
 
     [Fact]
+    public void ParseChoices_IgnoresBlankLinesAndTrimsOptions()
+    {
+        string[] result = MiscModule.ParseChoices("  red  \n\n \t\nblue\r\n");
+
+        Assert.Equal(["red", "blue"], result);
+    }
+
+    [Fact]
+    public void ParseChoices_ReturnsOnlyNonBlankOptions()
+    {
+        string[] result = MiscModule.ParseChoices("\n \n only choice \n\t");
+
+        Assert.Equal(["only choice"], result);
+    }
+
+    [Fact]
     public void GenerateRandomNumber_SupportsIntMaxValueAsInclusiveUpperBound()
     {
         int result = MiscModule.GenerateRandomNumber(int.MaxValue, int.MaxValue);


### PR DESCRIPTION
## Summary
- filter blank and whitespace-only lines before the `choose` command selects an option
- require at least two non-blank choices and trim each remaining choice
- add regression coverage for blank-line and whitespace handling

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~MiscModuleTests` — passed: 11 tests
- `dotnet build` — passed with 2 existing NU1903 warnings for SQLitePCLRaw.lib.e_sqlite3 2.1.6
- `dotnet test` — passed: 228 tests
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change only normalizes `choose` input lines before the existing random selection.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
