### PR TITLE
fix: correct dog command error messages

### DIFF
--- a/Modules/ImageModule.cs
+++ b/Modules/ImageModule.cs
@@ -138,17 +138,17 @@ public class ImageModule(CommandService commands, IServiceProvider serviceProvid
         catch (HttpRequestException httpEx)
         {
             Console.WriteLine($"[DOG API HTTP ERROR] {httpEx}");
-            await ReplyAsync("Sorry, I couldn't connect to the cat API right now. Please try again later.");
+            await ReplyAsync("Sorry, I couldn't connect to the dog API right now. Please try again later.");
         }
         catch (JsonException jsonEx)
         {
             Console.WriteLine($"[DOG API JSON ERROR] {jsonEx}");
-            await ReplyAsync("Sorry, I received an unexpected response from the cat API. Please try again later.");
+            await ReplyAsync("Sorry, I received an unexpected response from the dog API. Please try again later.");
         }
         catch (Exception ex)
         {
             Console.WriteLine($"[DOG COMMAND UNEXPECTED ERROR] {ex}");
-            await ReplyAsync($"An unexpected error occurred while fetching a cat image. The hoomans have been notified (not really, but they should check the logs).");
+            await ReplyAsync($"An unexpected error occurred while fetching a dog image. The hoomans have been notified (not really, but they should check the logs).");
         }
     }
 


### PR DESCRIPTION
## Summary
- correct the dog command’s HTTP, JSON, and unexpected-error responses so they refer to the dog API and dog images instead of cats

## Verification
- `dotnet build` — passed with 0 errors (2 NU1903 package-vulnerability warnings)
- `dotnet test --no-build` — passed, 226 tests
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: this only corrects three user-facing error strings; command behavior and metadata are unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
