### PR TITLE
fix: detect punctuated IPv4 URLs

### DIFF
--- a/Morpheus.Tests/UtilsTests.cs
+++ b/Morpheus.Tests/UtilsTests.cs
@@ -25,4 +25,30 @@ public class UtilsTests
     {
         Assert.False(Utils.ContainsUrl(text));
     }
+
+    [Theory]
+    [InlineData("(192.168.1.1)")]
+    [InlineData("\"192.168.1.1\"")]
+    [InlineData("See:192.168.1.1")]
+    [InlineData("Visit 192.168.1.1.")]
+    [InlineData("Connect to 192.168.1.1:8080/path")]
+    public void ContainsUrl_DetectsIpv4AddressesAfterPunctuation(string text)
+    {
+        Assert.True(Utils.ContainsUrl(text));
+    }
+
+    [Theory]
+    [InlineData("prefix192.168.1.1")]
+    [InlineData("user@192.168.1.1")]
+    [InlineData("user@[192.168.1.1]")]
+    [InlineData("user@[IPv4:192.168.1.1]")]
+    [InlineData("192.168.1.1.2")]
+    [InlineData("192.168.1.1suffix")]
+    [InlineData("192.168.1.1:abc")]
+    [InlineData("192.168.1.1:123456")]
+    [InlineData("192.168.1.1:80suffix")]
+    public void ContainsUrl_DoesNotTreatEmbeddedIpv4AddressesAsUrls(string text)
+    {
+        Assert.False(Utils.ContainsUrl(text));
+    }
 }

--- a/Utilities/Utils.cs
+++ b/Utilities/Utils.cs
@@ -10,7 +10,7 @@ public static class Utils
     private static readonly Regex _schemeRegex = new(@"\b(?:https?|ftp)://[\w\-\._~:/?#\[\]@!$&'()*+,;=%]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex _mdLinkRegex = new(@"\[[^\]]+\]\((?:https?://|ftp://|www\.)[^)\s]+\)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex _bareDomainRegex = new(@"(?<![a-z0-9.!#$%&'*+/=?^_`{|}~@-])(?:www\.)?(?:[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}(?::\d{1,5})?(?![a-z0-9.!#$%&'*+/=?^_`{|}~-]*@)(?:/[^\s]*)?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex _ipRegex = new(@"(?<=\s|^)(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(?::\d{1,5})?(?:/[^\s]*)?(?=\s|$)", RegexOptions.Compiled);
+    private static readonly Regex _ipRegex = new(@"(?<!@\[)(?<!@\[IPv4:)(?<![\w.@/+%-])(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(?::\d{1,5})?(?:/[^\s]*)?(?![\w@/:%+-]|\.[a-z0-9]|[^\s@]*@)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     public static string GetAssemblyVersion()
     {


### PR DESCRIPTION
## Summary
- detect IPv4 URL literals when common punctuation, rather than whitespace, delimits them
- avoid treating embedded addresses, IPv4 email domain literals, or malformed port suffixes as URLs
- add focused regression coverage for accepted and rejected boundaries

## Verification
- `dotnet build --consoleLoggerParameters:ErrorsOnly` — passed: 0 errors (2 warnings)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~UtilsTests --consoleLoggerParameters:ErrorsOnly` — passed: 40/40
- `dotnet test --no-build --filter 'FullyQualifiedName!~MiscModuleTests.NormalizeTimeUntilEventName_NormalizesCase' --consoleLoggerParameters:ErrorsOnly` — passed: 314/314
- `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 dotnet test --no-build --consoleLoggerParameters:ErrorsOnly` — 314 passed, 2 failed: the existing `MiscModuleTests.NormalizeTimeUntilEventName_NormalizesCase` cases require `tr-TR`, which is unavailable in this invariant-globalization runner
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low — the change is isolated to IPv4 boundary detection and includes positive and false-positive regression cases.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
