### PR TITLE
fix: preserve YouTube history across feed rollover

### DIFF
--- a/Database/DB.cs
+++ b/Database/DB.cs
@@ -98,6 +98,7 @@ public class DB(DbContextOptions<DB> options) : Microsoft.EntityFrameworkCore.Db
         modelBuilder.Entity<YoutubeSubscription>().HasIndex(s => new { s.ChannelDiscordId, s.YoutubeChannelId }).IsUnique();
         modelBuilder.Entity<YoutubeSubscription>().HasIndex(s => s.YoutubeChannelId);
         modelBuilder.Entity<YoutubeSeenVideo>().HasIndex(s => s.VideoId).IsUnique();
+        modelBuilder.Entity<YoutubeSeenVideo>().HasIndex(s => s.YoutubeChannelId);
         modelBuilder.Entity<YoutubeSubscription>()
             .HasOne(s => s.Webhook)
             .WithMany()

--- a/Jobs/YoutubeRssJob.cs
+++ b/Jobs/YoutubeRssJob.cs
@@ -67,7 +67,9 @@ public class YoutubeRssJob(DB db, YoutubeFeedService youtubeFeed, DiscordWebhook
 
             // If nothing from this channel has ever been seen, this is an initial run for it:
             // mark everything seen and only post the latest video to avoid backfilling history.
-            bool initialSeed = !entries.Any(e => seen.Contains(e.VideoId));
+            // Check all history for the channel because older seen videos may have rolled out of
+            // the feed's current response.
+            bool initialSeed = !await HasFeedHistoryAsync(db, youtubeChannelId);
             if (initialSeed)
             {
                 YoutubeFeedService.VideoEntry latest = entries.OrderByDescending(e => e.Published).First();
@@ -114,6 +116,9 @@ public class YoutubeRssJob(DB db, YoutubeFeedService youtubeFeed, DiscordWebhook
 
         return allSucceeded;
     }
+
+    internal static Task<bool> HasFeedHistoryAsync(DB db, string youtubeChannelId) =>
+        db.YoutubeSeenVideos.AnyAsync(video => video.YoutubeChannelId == youtubeChannelId);
 
     private async Task<bool> SendAsync(
         YoutubeSubscription sub,

--- a/Migrations/20260805021319_IndexYoutubeSeenVideosByChannel.Designer.cs
+++ b/Migrations/20260805021319_IndexYoutubeSeenVideosByChannel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Morpheus.Database;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Morpheus.Migrations
 {
     [DbContext(typeof(DB))]
-    partial class DBModelSnapshot : ModelSnapshot
+    [Migration("20260805021319_IndexYoutubeSeenVideosByChannel")]
+    partial class IndexYoutubeSeenVideosByChannel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260805021319_IndexYoutubeSeenVideosByChannel.cs
+++ b/Migrations/20260805021319_IndexYoutubeSeenVideosByChannel.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Morpheus.Migrations
+{
+    /// <inheritdoc />
+    public partial class IndexYoutubeSeenVideosByChannel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_YoutubeSeenVideos_YoutubeChannelId",
+                table: "YoutubeSeenVideos",
+                column: "YoutubeChannelId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_YoutubeSeenVideos_YoutubeChannelId",
+                table: "YoutubeSeenVideos");
+        }
+    }
+}

--- a/Morpheus.Tests/YoutubeRssJobTests.cs
+++ b/Morpheus.Tests/YoutubeRssJobTests.cs
@@ -1,3 +1,6 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
 using Morpheus.Database.Models;
 using Morpheus.Jobs;
 
@@ -5,6 +8,32 @@ namespace Morpheus.Tests;
 
 public class YoutubeRssJobTests
 {
+    [Fact]
+    public async Task HasFeedHistoryAsync_DistinguishesExistingChannelFromUnknownChannel()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        Assert.False(await YoutubeRssJob.HasFeedHistoryAsync(db, "channel-1"));
+
+        db.YoutubeSeenVideos.Add(new YoutubeSeenVideo
+        {
+            YoutubeChannelId = "channel-1",
+            VideoId = "video-that-is-no-longer-in-the-feed"
+        });
+        await db.SaveChangesAsync();
+
+        bool hasHistory = await YoutubeRssJob.HasFeedHistoryAsync(db, "channel-1");
+
+        Assert.True(hasHistory);
+        Assert.False(await YoutubeRssJob.HasFeedHistoryAsync(db, "channel-2"));
+    }
+
     [Fact]
     public async Task DispatchAsync_WhenOneDeliveryFails_ReportsFailureAndAttemptsEverySubscriber()
     {


### PR DESCRIPTION
## Summary
- distinguish first-time YouTube feed seeding from existing channels whose previously seen videos rolled out of the current feed
- deliver every unseen current video for existing channels instead of silently marking older unseen entries as seeded
- index YouTube history by channel and include the generated EF Core migration
- add regression coverage for existing, empty, and unrelated channel history

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~YoutubeRssJobTests --no-restore` — passed: 3/3
- `dotnet build` — passed with the existing `NU1903` SQLite package warning
- EF migration SQL generation — passed; generated script contains `IX_YoutubeSeenVideos_YoutubeChannelId`
- `dotnet test` — partial: 301 passed, 2 failed in `MiscModuleTests.NormalizeTimeUntilEventName_NormalizesCase` because this runner lacks `tr-TR` support in globalization-invariant mode
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Medium: changes feed rollover delivery behavior and adds one non-unique database index; first-time latest-only seeding remains unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
