### PR TITLE
fix: parse stock share amounts invariantly

### DIFF
--- a/Modules/StocksModule.cs
+++ b/Modules/StocksModule.cs
@@ -9,6 +9,7 @@ using Morpheus.Database.Models;
 using Morpheus.Extensions;
 using Morpheus.Services;
 using Morpheus.Utilities;
+using System.Globalization;
 using System.Text;
 
 namespace Morpheus.Modules;
@@ -17,6 +18,12 @@ namespace Morpheus.Modules;
 [Summary("Pseudo stock market — invest in users, guilds, and channels.")]
 public class StocksModule(DB dbContext, StocksService stocksService, ChannelService channelService, UsersService usersService) : ModuleBase<SocketCommandContextExtended>
 {
+    internal static bool TryParseShareAmount(string value, out decimal amount)
+    {
+        const NumberStyles styles = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign;
+        return decimal.TryParse(value, styles, CultureInfo.InvariantCulture, out amount) && amount > 0;
+    }
+
     #region Target Resolution
 
     /// <summary>
@@ -116,7 +123,7 @@ public class StocksModule(DB dbContext, StocksService stocksService, ChannelServ
         decimal? sharesToSell = null;
         if (amountStr.ToLower() != "all")
         {
-            if (!decimal.TryParse(amountStr, out decimal parsed) || parsed <= 0)
+            if (!TryParseShareAmount(amountStr, out decimal parsed))
             {
                 await ReplyAsync("Invalid amount. Use a positive number or `all`.");
                 return;
@@ -168,7 +175,7 @@ public class StocksModule(DB dbContext, StocksService stocksService, ChannelServ
         decimal? sharesToTransfer = null;
         if (amountStr.ToLower() != "all")
         {
-            if (!decimal.TryParse(amountStr, out decimal parsed) || parsed <= 0)
+            if (!TryParseShareAmount(amountStr, out decimal parsed))
             {
                 await ReplyAsync("Invalid amount. Use a positive number or `all`.");
                 return;

--- a/Morpheus.Tests/StocksModuleTests.cs
+++ b/Morpheus.Tests/StocksModuleTests.cs
@@ -1,0 +1,41 @@
+using System.Globalization;
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class StocksModuleTests
+{
+    [Fact]
+    public void TryParseShareAmount_UsesInvariantDecimalSeparator()
+    {
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo commaDecimalCulture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        commaDecimalCulture.NumberFormat.NumberDecimalSeparator = ",";
+        commaDecimalCulture.NumberFormat.NumberGroupSeparator = ".";
+
+        try
+        {
+            CultureInfo.CurrentCulture = commaDecimalCulture;
+
+            bool parsed = StocksModule.TryParseShareAmount("12.50", out decimal amount);
+
+            Assert.True(parsed);
+            Assert.Equal(12.50m, amount);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Theory]
+    [InlineData("12,50")]
+    [InlineData("1,000")]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("not-a-number")]
+    public void TryParseShareAmount_RejectsAmbiguousOrNonPositiveValues(string value)
+    {
+        Assert.False(StocksModule.TryParseShareAmount(value, out _));
+    }
+}


### PR DESCRIPTION
## Summary
- parse manually entered `stock sell` and `stock transfer` share amounts with an invariant decimal separator
- reject ambiguous grouping/comma-decimal input instead of risking a much larger share quantity
- add regression coverage under a comma-decimal current culture

## Verification
- `dotnet build --no-restore` — passed with 0 errors (one existing vulnerable-package warning)
- `dotnet test --filter FullyQualifiedName~StocksModuleTests --no-restore` — passed, 6/6
- `dotnet test --no-restore --filter 'FullyQualifiedName!~NormalizeTimeUntilEventName_NormalizesCase'` — passed, 306/306
- `dotnet test --no-restore` — 306 passed, 2 failed because this runner is in globalization-invariant mode and cannot load `tr-TR` in the existing `MiscModuleTests`
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change is limited to sell/transfer share parsing; positive invariant decimal values and `all` retain their existing behavior, while culture-dependent and grouped values are rejected.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
