### PR TITLE
fix: allow info command without owner configuration

### DIFF
--- a/Modules/MiscModule.cs
+++ b/Modules/MiscModule.cs
@@ -358,8 +358,6 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
     [RateLimit(3, 10)]
     public async Task Info()
     {
-        ulong ownerId = ulong.Parse(Env.Variables["OWNER_ID"]);
-
         EmbedBuilder builder = new()
         {
             Color = Colors.Blue,
@@ -377,15 +375,16 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
             -# Version: v{Utils.GetAssemblyVersion()}
             """,
             ThumbnailUrl = Context.Client.CurrentUser.GetAvatarUrl(),
-            Footer = new EmbedFooterBuilder()
-            {
-                Text = "Made with ❤️ by vycdev",
-                IconUrl = (await Context.Client.Rest.GetUserAsync(ownerId)).GetAvatarUrl()
-            }
+            Footer = BuildInfoFooter()
         };
 
         await ReplyAsync(embed: builder.Build());
     }
+
+    internal static EmbedFooterBuilder BuildInfoFooter() => new()
+    {
+        Text = "Made with ❤️ by vycdev"
+    };
 
     [Name("Uptime")]
     [Summary("Displays the bot's uptime.")]

--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -60,6 +60,15 @@ public class MiscModuleTests
     }
 
     [Fact]
+    public void BuildInfoFooter_DoesNotDependOnOwnerConfiguration()
+    {
+        Discord.EmbedFooterBuilder footer = MiscModule.BuildInfoFooter();
+
+        Assert.Equal("Made with ❤️ by vycdev", footer.Text);
+        Assert.Null(footer.IconUrl);
+    }
+
+    [Fact]
     public void ParseChoices_IgnoresBlankLinesAndTrimsOptions()
     {
         string[] result = MiscModule.ParseChoices("  red  \n\n \t\nblue\r\n");


### PR DESCRIPTION
## Summary
- keep the public `info` command working when `OWNER_ID` is missing or malformed
- remove the unnecessary owner-user REST lookup from the informational footer
- cover the configuration-independent footer with a regression test

## Verification
- `dotnet build` — passed with 0 errors (existing package/globalization warnings remain)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~BuildInfoFooter_DoesNotDependOnOwnerConfiguration --no-restore` — passed (1/1)
- `dotnet test` — 301 passed, 2 failed because this runner enforces globalization-invariant mode and the existing Turkish-culture tests cannot load `tr-TR`
- `dotnet test --no-restore --filter 'FullyQualifiedName!~NormalizeTimeUntilEventName_NormalizesCase'` — passed (301/301)
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: this only removes a decorative owner avatar from the info footer and eliminates its configuration/network dependency.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
