### PR TITLE
fix: stabilize activity graph tie ordering

### DIFF
--- a/Morpheus.Tests/ActivityGraphServiceTests.cs
+++ b/Morpheus.Tests/ActivityGraphServiceTests.cs
@@ -63,6 +63,63 @@ public class ActivityGraphServiceTests
     }
 
     [Fact]
+    public async Task BuildUserActivityGraphAsync_UsesUserIdToBreakTies()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        Guild guild = new() { DiscordId = 100, Name = "Test guild" };
+        List<User> users = [.. Enumerable.Range(1, 11)
+            .Select(i => new User { DiscordId = (ulong)(1000 + i), Username = $"user-{i:D2}" })];
+        db.Add(guild);
+        db.Users.AddRange(users);
+        await db.SaveChangesAsync();
+
+        DateTime start = new(2026, 5, 24, 0, 0, 0, DateTimeKind.Utc);
+        db.UserActivity.AddRange(users
+            .AsEnumerable()
+            .Reverse()
+            .Select((user, index) => new UserActivity
+            {
+                UserId = user.Id,
+                GuildId = guild.Id,
+                DiscordChannelId = 2001,
+                DiscordMessageId = (ulong)(3001 + index),
+                XpGained = 10,
+                InsertDate = start
+            }));
+        await db.SaveChangesAsync();
+
+        ActivityGraphService service = new(db);
+        ActivityGraphRange range = new(Days: 7, Start: start, ExplicitStart: start);
+        ActivityGraphBuildResult topUsers = await service.BuildUserActivityGraphAsync(
+            range,
+            guildId: guild.Id,
+            global: false,
+            mentionedDiscordIds: [],
+            cumulative: false,
+            rollingWindowDays: null);
+
+        ActivityGraphBuildResult mentionedUsers = await service.BuildUserActivityGraphAsync(
+            range,
+            guildId: guild.Id,
+            global: false,
+            mentionedDiscordIds: users.AsEnumerable().Reverse().Select(user => user.DiscordId),
+            cumulative: false,
+            rollingWindowDays: null);
+
+        IEnumerable<string> expectedOrder = users.OrderBy(user => user.Id).Select(user => user.Username);
+        Assert.Equal(expectedOrder.Take(10), topUsers.Series.Keys);
+        Assert.Equal(expectedOrder, mentionedUsers.Series.Keys);
+    }
+
+    [Fact]
     public void ParseDaysString_ClampsPresetDaysForNonOwner()
     {
         ActivityGraphParseResult result = ActivityGraphService.ParseDaysString(

--- a/Services/ActivityGraphService.cs
+++ b/Services/ActivityGraphService.cs
@@ -188,6 +188,7 @@ public class ActivityGraphService(DB dbContext)
             .GroupBy(ua => ua.UserId)
             .Select(g => new { UserId = g.Key, Total = g.Sum(x => x.XpGained) })
             .OrderByDescending(x => x.Total)
+            .ThenBy(x => x.UserId)
             .Take(10)
             .ToListAsync();
 
@@ -232,6 +233,7 @@ public class ActivityGraphService(DB dbContext)
             .GroupBy(ua => ua.UserId)
             .Select(g => new { UserId = g.Key, Total = g.Sum(x => x.XpGained) })
             .OrderByDescending(x => x.Total)
+            .ThenBy(x => x.UserId)
             .ToListAsync();
 
         Dictionary<int, Dictionary<DateTime, int>> byDay = await GetUserActivityByDayAsync(query);


### PR DESCRIPTION
## Summary
- make activity graph ranking deterministic by using user ID as the tie-breaker for equal XP totals
- cover both the top-ten boundary and explicitly mentioned-user ordering with a SQLite regression test

## Verification
- `dotnet build` — passed (NU1903 warning for the existing SQLite package version)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~ActivityGraphServiceTests --no-restore` — passed, 11/11
- `dotnet test` — 298/300 passed; the same two `MiscModuleTests` failures occur on `develop` (297/299) because this runner's invariant globalization mode cannot load `tr-TR`
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: this only defines stable ordering for tied aggregate totals and adds regression coverage.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
