### PR TITLE
fix: stabilize button leaderboard tie ordering

### DIFF
--- a/Modules/ButtonModule.cs
+++ b/Modules/ButtonModule.cs
@@ -9,6 +9,12 @@ using System.Text;
 
 namespace Morpheus.Modules;
 
+internal sealed class ButtonGuildScore
+{
+    public int? GuildId { get; init; }
+    public long Score { get; init; }
+}
+
 public class ButtonModule(DB dbContext) : ModuleBase<SocketCommandContextExtended>
 {
     [Name("Press the Button")]
@@ -59,6 +65,24 @@ public class ButtonModule(DB dbContext) : ModuleBase<SocketCommandContextExtende
     internal static bool IsNewBestScore(long score, long? bestScore) =>
         bestScore.HasValue && score > bestScore.Value;
 
+    internal static IOrderedQueryable<ButtonGamePress> OrderPressScores(
+        IQueryable<ButtonGamePress> presses) =>
+        presses
+            .OrderByDescending(press => press.Score)
+            .ThenBy(press => press.Id);
+
+    internal static IOrderedQueryable<ButtonGuildScore> OrderGuildScores(
+        IQueryable<ButtonGamePress> presses) =>
+        presses
+            .GroupBy(press => press.GuildId)
+            .Select(group => new ButtonGuildScore
+            {
+                GuildId = group.Key,
+                Score = group.Sum(press => press.Score)
+            })
+            .OrderByDescending(score => score.Score)
+            .ThenBy(score => score.GuildId);
+
     // Top global 
     [Name("Top Button Global")]
     [Summary("Get the top global button press scores.")]
@@ -68,8 +92,7 @@ public class ButtonModule(DB dbContext) : ModuleBase<SocketCommandContextExtende
     public async Task TopGlobal()
     {
         // Get top 10 button presses 
-        List<ButtonGamePress> buttonGamePresses = await dbContext.ButtonGamePresses
-            .OrderByDescending(b => b.Score)
+        List<ButtonGamePress> buttonGamePresses = await OrderPressScores(dbContext.ButtonGamePresses)
             .Take(10)
             .ToListAsync();
 
@@ -112,9 +135,8 @@ public class ButtonModule(DB dbContext) : ModuleBase<SocketCommandContextExtende
         Guild guild = Context.DbGuild!;
 
         // Get top 10 button presses 
-        List<ButtonGamePress> buttonGamePresses = await dbContext.ButtonGamePresses
-            .Where(b => b.GuildId == guild.Id)
-            .OrderByDescending(b => b.Score)
+        List<ButtonGamePress> buttonGamePresses = await OrderPressScores(
+                dbContext.ButtonGamePresses.Where(b => b.GuildId == guild.Id))
             .Take(10)
             .ToListAsync();
 
@@ -151,9 +173,8 @@ public class ButtonModule(DB dbContext) : ModuleBase<SocketCommandContextExtende
     public async Task TopIndividualUser()
     {
         // Get top 10 button presses 
-        List<ButtonGamePress> buttonGamePresses = await dbContext.ButtonGamePresses
-            .Where(b => b.GuildId == null)
-            .OrderByDescending(b => b.Score)
+        List<ButtonGamePress> buttonGamePresses = await OrderPressScores(
+                dbContext.ButtonGamePresses.Where(b => b.GuildId == null))
             .Take(10)
             .ToListAsync();
 
@@ -193,9 +214,8 @@ public class ButtonModule(DB dbContext) : ModuleBase<SocketCommandContextExtende
         User user = Context.DbUser!;
 
         // Get top 10 button presses 
-        List<ButtonGamePress> buttonGamePresses = await dbContext.ButtonGamePresses
-            .Where(b => b.UserId == user.Id)
-            .OrderByDescending(b => b.Score)
+        List<ButtonGamePress> buttonGamePresses = await OrderPressScores(
+                dbContext.ButtonGamePresses.Where(b => b.UserId == user.Id))
             .Take(10)
             .ToListAsync();
 
@@ -238,9 +258,8 @@ public class ButtonModule(DB dbContext) : ModuleBase<SocketCommandContextExtende
         Guild guild = Context.DbGuild!;
 
         // Get top 10 button presses 
-        List<ButtonGamePress> buttonGamePresses = await dbContext.ButtonGamePresses
-            .Where(b => b.UserId == user.Id && b.GuildId == guild.Id)
-            .OrderByDescending(b => b.Score)
+        List<ButtonGamePress> buttonGamePresses = await OrderPressScores(
+                dbContext.ButtonGamePresses.Where(b => b.UserId == user.Id && b.GuildId == guild.Id))
             .Take(10)
             .ToListAsync();
 
@@ -275,10 +294,8 @@ public class ButtonModule(DB dbContext) : ModuleBase<SocketCommandContextExtende
     public async Task TopGuildGlobal()
     {
         // Get top 10 button presses 
-        var buttonGamePresses = await dbContext.ButtonGamePresses
-            .GroupBy(b => b.GuildId)
-            .Select(g => new { GuildId = g.Key, Score = g.Sum(b => b.Score) })
-            .OrderByDescending(g => g.Score)
+        List<ButtonGuildScore> buttonGamePresses = await OrderGuildScores(
+                dbContext.ButtonGamePresses)
             .Take(10)
             .ToListAsync();
 

--- a/Morpheus.Tests/ButtonModuleTests.cs
+++ b/Morpheus.Tests/ButtonModuleTests.cs
@@ -1,3 +1,7 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
 using Morpheus.Modules;
 
 namespace Morpheus.Tests;
@@ -15,5 +19,80 @@ public class ButtonModuleTests
         bool expected)
     {
         Assert.Equal(expected, ButtonModule.IsNewBestScore(score, bestScore));
+    }
+
+    [Fact]
+    public void OrderPressScores_UsesIdToBreakScoreTies()
+    {
+        ButtonGamePress[] presses =
+        [
+            new() { Id = 3, Score = 100 },
+            new() { Id = 1, Score = 100 },
+            new() { Id = 4, Score = 200 },
+            new() { Id = 2, Score = 100 }
+        ];
+
+        int[] result =
+        [.. ButtonModule.OrderPressScores(presses.AsQueryable()).Select(press => press.Id)];
+
+        Assert.Equal([4, 1, 2, 3], result);
+    }
+
+    [Fact]
+    public void OrderGuildScores_UsesGuildIdToBreakScoreTies()
+    {
+        ButtonGamePress[] presses =
+        [
+            new() { GuildId = 3, Score = 100 },
+            new() { GuildId = 1, Score = 100 },
+            new() { GuildId = 4, Score = 200 },
+            new() { GuildId = 2, Score = 100 }
+        ];
+
+        int?[] result =
+        [.. ButtonModule.OrderGuildScores(presses.AsQueryable()).Select(score => score.GuildId)];
+
+        Assert.Equal([4, 1, 2, 3], result);
+    }
+
+    [Fact]
+    public async Task OrderGuildScores_ExecutesGroupedDatabaseQuery()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        User user = new() { DiscordId = 1, Username = "button-user" };
+        Guild[] guilds =
+        [
+            new() { DiscordId = 1, Name = "guild-1" },
+            new() { DiscordId = 2, Name = "guild-2" },
+            new() { DiscordId = 3, Name = "guild-3" },
+            new() { DiscordId = 4, Name = "guild-4" }
+        ];
+        db.Add(user);
+        db.AddRange(guilds);
+        await db.SaveChangesAsync();
+
+        db.ButtonGamePresses.AddRange(
+            new() { UserId = user.Id, GuildId = guilds[2].Id, Score = 40 },
+            new() { UserId = user.Id, GuildId = guilds[0].Id, Score = 100 },
+            new() { UserId = user.Id, GuildId = guilds[3].Id, Score = 200 },
+            new() { UserId = user.Id, GuildId = guilds[1].Id, Score = 100 },
+            new() { UserId = user.Id, GuildId = guilds[2].Id, Score = 60 });
+        await db.SaveChangesAsync();
+
+        List<int?> result = await ButtonModule.OrderGuildScores(db.ButtonGamePresses)
+            .Select(score => score.GuildId)
+            .ToListAsync();
+
+        Assert.Equal(
+            [guilds[3].Id, guilds[0].Id, guilds[1].Id, guilds[2].Id],
+            result);
     }
 }


### PR DESCRIPTION
## Summary
- add deterministic ID tie-breakers to every button press top-10 query
- add a deterministic guild-ID tie-breaker to the grouped guild leaderboard
- cover in-memory ordering and execute the grouped query through EF Core SQLite

## Verification
- `dotnet build --nologo` — passed (0 errors; existing SQLite package advisory warning)
- `dotnet test --nologo --filter FullyQualifiedName~ButtonModuleTests` — passed (7/7)
- `dotnet test --no-build --nologo` — partial: 300 passed, 2 failed because this runner is in globalization-invariant mode and cannot load `tr-TR`; the same two `MiscModuleTests` failures occur on the unchanged base
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: this only makes equal-score leaderboard ordering deterministic; aggregate query translation and execution are covered by SQLite.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
