### PR TITLE
fix: allow duplicate environment keys

### DIFF
--- a/Morpheus.Tests/EnvTests.cs
+++ b/Morpheus.Tests/EnvTests.cs
@@ -1,0 +1,39 @@
+using Morpheus.Utilities;
+
+namespace Morpheus.Tests;
+
+[CollectionDefinition("Environment variable tests", DisableParallelization = true)]
+public class EnvironmentVariableTestCollection
+{
+}
+
+[Collection("Environment variable tests")]
+public class EnvTests
+{
+    [Fact]
+    public void Load_DuplicateKeys_UsesLastValue()
+    {
+        string key = $"MORPHEUS_ENV_TEST_{Guid.NewGuid():N}";
+        string? originalEnvironmentValue = Environment.GetEnvironmentVariable(key);
+        Dictionary<string, string> originalVariables = new(Env.Variables);
+        string filePath = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllLines(filePath, [$"{key}=first", $"{key}=second"]);
+
+            Env.Load(filePath);
+
+            Assert.Equal("second", Env.Variables[key]);
+            Assert.Equal("second", Environment.GetEnvironmentVariable(key));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(key, originalEnvironmentValue);
+            Env.Variables.Clear();
+            foreach ((string existingKey, string existingValue) in originalVariables)
+                Env.Variables[existingKey] = existingValue;
+            File.Delete(filePath);
+        }
+    }
+}

--- a/Utilities/Env.cs
+++ b/Utilities/Env.cs
@@ -27,7 +27,7 @@ public class Env
                 string key = parts[0].Trim();
                 string value = parts[1].Trim();
                 Environment.SetEnvironmentVariable(key, value);
-                Variables.Add(key, value);
+                Variables[key] = value;
             }
         }
 


### PR DESCRIPTION
## Summary
- make duplicate keys in `.env` files use the last declared value instead of aborting startup
- add an isolated regression test that restores process-wide environment state

## Verification
- `dotnet build` — passed (existing NU1903 warning for SQLitePCLRaw.lib.e_sqlite3 2.1.6)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~EnvTests --no-restore` — passed (1/1)
- `dotnet test` — 298 passed, 2 failed due to unavailable `tr-tr` culture in globalization-invariant mode; the same 2 focused failures reproduce on `upstream/develop`
- `git diff --check` — passed

## Risk
- Low: the change only replaces throwing dictionary insertion with last-value-wins assignment, matching process environment behavior and documented `.env` precedence.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
