### PR TITLE
fix: align leaderboard rank tie ordering

### DIFF
--- a/Morpheus.Tests/ActivityLeaderboardServiceTests.cs
+++ b/Morpheus.Tests/ActivityLeaderboardServiceTests.cs
@@ -162,4 +162,80 @@ public class ActivityLeaderboardServiceTests
                 $"[{ActivityLeaderboardService.PageSize + index + 1}] | {user.Username}: Level 0 with 100 XP"),
             secondPage.Page.Lines);
     }
+
+    [Fact]
+    public async Task Leaderboards_RankTiesByTheSameUserIdOrderAsDisplayedRows()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        User firstUser = new() { DiscordId = 1, Username = "first" };
+        User secondUser = new() { DiscordId = 2, Username = "second" };
+        Guild guild = new() { DiscordId = 1, Name = "Test guild" };
+        db.AddRange(firstUser, secondUser, guild);
+        await db.SaveChangesAsync();
+
+        db.UserLevels.AddRange(
+            new UserLevels
+            {
+                UserId = firstUser.Id,
+                GuildId = guild.Id,
+                TotalXp = 100,
+                UserMessageCount = 1,
+                UserAverageMessageLength = 10
+            },
+            new UserLevels
+            {
+                UserId = secondUser.Id,
+                GuildId = guild.Id,
+                TotalXp = 100,
+                UserMessageCount = 1,
+                UserAverageMessageLength = 10
+            });
+        db.UserActivity.AddRange(
+            new UserActivity
+            {
+                UserId = firstUser.Id,
+                GuildId = guild.Id,
+                DiscordMessageId = 1,
+                XpGained = 10
+            },
+            new UserActivity
+            {
+                UserId = secondUser.Id,
+                GuildId = guild.Id,
+                DiscordMessageId = 2,
+                XpGained = 10
+            });
+        await db.SaveChangesAsync();
+
+        ActivityLeaderboardService service = new(db);
+        int viewerUserId = secondUser.Id;
+        ActivityLeaderboardQueryResult[] results =
+        [
+            await service.GetGuildXpLeaderboardAsync(guild.Id, guild.Name, viewerUserId, page: 1),
+            await service.GetGuildPastXpLeaderboardAsync(guild.Id, guild.Name, viewerUserId, days: 1, page: 1),
+            await service.GetGlobalXpLeaderboardAsync(viewerUserId, page: 1),
+            await service.GetGlobalPastXpLeaderboardAsync(viewerUserId, days: 1, page: 1),
+            await service.GetGuildMessageLeaderboardAsync(guild.Id, guild.Name, viewerUserId, page: 1),
+            await service.GetGuildPastMessageLeaderboardAsync(guild.Id, guild.Name, viewerUserId, days: 1, page: 1),
+            await service.GetGlobalMessageLeaderboardAsync(viewerUserId, page: 1),
+            await service.GetGlobalPastMessageLeaderboardAsync(viewerUserId, days: 1, page: 1),
+            await service.GetGuildAverageLengthLeaderboardAsync(guild.Id, guild.Name, viewerUserId, page: 1),
+            await service.GetGlobalAverageLengthLeaderboardAsync(viewerUserId, page: 1)
+        ];
+
+        Assert.All(results, result =>
+        {
+            Assert.True(result.Success);
+            Assert.NotNull(result.Page);
+            Assert.Equal("Your rank: #2", result.Page.RankLine);
+        });
+    }
 }

--- a/Services/ActivityLeaderboardService.cs
+++ b/Services/ActivityLeaderboardService.cs
@@ -423,7 +423,10 @@ public class ActivityLeaderboardService(DB dbContext)
 
         int better = await dbContext.UserLevels
             .AsNoTracking()
-            .Where(ul => ul.GuildId == guildId && ul.TotalXp > userLevel.TotalXp)
+            .Where(ul =>
+                ul.GuildId == guildId &&
+                (ul.TotalXp > userLevel.TotalXp ||
+                 (ul.TotalXp == userLevel.TotalXp && ul.UserId < viewerUserId.Value)))
             .CountAsync();
 
         return $"Your rank: #{better + 1}";
@@ -447,8 +450,10 @@ public class ActivityLeaderboardService(DB dbContext)
         int better = await dbContext.UserLevels
             .AsNoTracking()
             .GroupBy(ul => ul.UserId)
-            .Select(g => new { Total = g.Sum(ul => ul.TotalXp) })
-            .CountAsync(x => x.Total > myTotal);
+            .Select(g => new { UserId = g.Key, Total = g.Sum(ul => ul.TotalXp) })
+            .CountAsync(x =>
+                x.Total > myTotal ||
+                (x.Total == myTotal && x.UserId < viewerUserId.Value));
 
         return $"Your rank: #{better + 1}";
     }
@@ -465,8 +470,10 @@ public class ActivityLeaderboardService(DB dbContext)
         int mySum = await baseQuery.Where(ua => ua.UserId == viewerUserId.Value).SumAsync(ua => ua.XpGained);
         int better = await baseQuery
             .GroupBy(ua => ua.UserId)
-            .Select(g => new { Sum = g.Sum(ua => ua.XpGained) })
-            .CountAsync(x => x.Sum > mySum);
+            .Select(g => new { UserId = g.Key, Sum = g.Sum(ua => ua.XpGained) })
+            .CountAsync(x =>
+                x.Sum > mySum ||
+                (x.Sum == mySum && x.UserId < viewerUserId.Value));
 
         return $"Your rank: #{better + 1}";
     }
@@ -485,7 +492,10 @@ public class ActivityLeaderboardService(DB dbContext)
 
         int better = await dbContext.UserLevels
             .AsNoTracking()
-            .Where(ul => ul.GuildId == guildId && ul.UserMessageCount > userLevel.UserMessageCount)
+            .Where(ul =>
+                ul.GuildId == guildId &&
+                (ul.UserMessageCount > userLevel.UserMessageCount ||
+                 (ul.UserMessageCount == userLevel.UserMessageCount && ul.UserId < viewerUserId.Value)))
             .CountAsync();
 
         return $"Your rank: #{better + 1}";
@@ -509,8 +519,10 @@ public class ActivityLeaderboardService(DB dbContext)
         int better = await dbContext.UserLevels
             .AsNoTracking()
             .GroupBy(ul => ul.UserId)
-            .Select(g => new { Count = g.Sum(ul => ul.UserMessageCount) })
-            .CountAsync(x => x.Count > myCount);
+            .Select(g => new { UserId = g.Key, Count = g.Sum(ul => ul.UserMessageCount) })
+            .CountAsync(x =>
+                x.Count > myCount ||
+                (x.Count == myCount && x.UserId < viewerUserId.Value));
 
         return $"Your rank: #{better + 1}";
     }
@@ -527,8 +539,10 @@ public class ActivityLeaderboardService(DB dbContext)
         int myCount = await baseQuery.CountAsync(ua => ua.UserId == viewerUserId.Value);
         int better = await baseQuery
             .GroupBy(ua => ua.UserId)
-            .Select(g => new { Count = g.Count() })
-            .CountAsync(x => x.Count > myCount);
+            .Select(g => new { UserId = g.Key, Count = g.Count() })
+            .CountAsync(x =>
+                x.Count > myCount ||
+                (x.Count == myCount && x.UserId < viewerUserId.Value));
 
         return $"Your rank: #{better + 1}";
     }
@@ -550,7 +564,9 @@ public class ActivityLeaderboardService(DB dbContext)
             .Where(ul =>
                 ul.GuildId == guildId &&
                 ul.UserMessageCount > 0 &&
-                ul.UserAverageMessageLength > userLevel.UserAverageMessageLength)
+                (ul.UserAverageMessageLength > userLevel.UserAverageMessageLength ||
+                 (ul.UserAverageMessageLength == userLevel.UserAverageMessageLength &&
+                  ul.UserId < viewerUserId.Value)))
             .CountAsync();
 
         return $"Your rank: #{better + 1}";
@@ -581,11 +597,14 @@ public class ActivityLeaderboardService(DB dbContext)
             .GroupBy(ul => ul.UserId)
             .Select(g => new
             {
+                UserId = g.Key,
                 SumLen = g.Sum(ul => ul.UserAverageMessageLength * ul.UserMessageCount),
                 SumCount = g.Sum(ul => ul.UserMessageCount)
             })
             .Where(x => x.SumCount > 0)
-            .CountAsync(x => (x.SumLen / x.SumCount) > myAverage);
+            .CountAsync(x =>
+                (x.SumLen / x.SumCount) > myAverage ||
+                ((x.SumLen / x.SumCount) == myAverage && x.UserId < viewerUserId.Value));
 
         return $"Your rank: #{better + 1}";
     }


### PR DESCRIPTION
## Summary
- make every activity leaderboard's `Your rank` calculation use the same user-ID tie-breaker as its displayed rows
- add SQLite regression coverage for tied XP, message-count, and average-length rankings across guild/global and all-time/recent variants

## Verification
- `dotnet build` — passed (with the existing SQLitePCLRaw NU1903 advisory warning)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~ActivityLeaderboardServiceTests --no-restore` — passed, 7/7
- `dotnet test --no-build` — 298 passed, 2 failed because this runner cannot load `tr-TR` in globalization-invariant mode; the same two `MiscModuleTests` failures were reproduced on unmodified `upstream/develop`
- `git diff --check` — passed

## Risk
- Low: this only resolves equal-score rank positions using the ordering already applied to leaderboard rows, with all query variants exercised against SQLite.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
