### PR TITLE
fix: preserve duration text in reminders

### DIFF
--- a/Modules/UtilityModule.cs
+++ b/Modules/UtilityModule.cs
@@ -19,7 +19,7 @@ public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtend
         ReminderDurationTokenPatternText,
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex ReminderDurationSequencePattern = new(
-        $"{ReminderDurationTokenPatternText}(?:\\s*(?:(?:,\\s*)?and|[,;])\\s*{ReminderDurationTokenPatternText})*",
+        $"^\\s*{ReminderDurationTokenPatternText}(?:\\s*(?:(?:,\\s*)?and|[,;])?\\s*{ReminderDurationTokenPatternText})*",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex LeadingReminderSeparatorPattern = new(
         "^[,;:\\-]\\s*",
@@ -112,48 +112,10 @@ public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtend
 
         // No separate ping field — users can include mentions in the reminder text if desired.
 
-        // Find all number+unit tokens
-        MatchCollection matches = ReminderDurationTokenPattern.Matches(input);
-
-        if (matches.Count == 0)
+        if (!TryParseReminderDuration(input, out double totalSeconds))
         {
             await ReplyAsync("Could not parse a duration. Examples: `5 days`, `3 hours and 30 minutes`, `7 weeks 2 minutes`. Supported units: seconds, minutes, hours, days, weeks, months, years.");
             return;
-        }
-
-        // Sum timespan
-        double totalSeconds = 0;
-        foreach (Match m in matches)
-        {
-            if (!long.TryParse(m.Groups[1].Value, out var number)) continue;
-            string unit = m.Groups[2].Value.ToLowerInvariant();
-
-            switch (unit)
-            {
-                case var u when u.StartsWith("y") || u.StartsWith("yr"):
-                    totalSeconds += (double)number * 365 * 24 * 3600; // years -> 365 days
-                    break;
-                case var u when u.StartsWith("mo"):
-                    totalSeconds += (double)number * 30 * 24 * 3600; // months -> 30 days
-                    break;
-                case var u when u.StartsWith("w"):
-                    totalSeconds += (double)number * 7 * 24 * 3600;
-                    break;
-                case var u when u.StartsWith("d"):
-                    totalSeconds += (double)number * 24 * 3600;
-                    break;
-                case var u when u.StartsWith("h"):
-                    totalSeconds += (double)number * 3600;
-                    break;
-                case var u when u.StartsWith("m") && (u == "m" || u.StartsWith("min") || u.StartsWith("mins")):
-                    totalSeconds += (double)number * 60;
-                    break;
-                case var u when u.StartsWith("s"):
-                    totalSeconds += (double)number;
-                    break;
-                default:
-                    break;
-            }
         }
 
         if (totalSeconds <= 0)
@@ -216,9 +178,53 @@ public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtend
         await ReplyAsync($"Reminder scheduled for {due:yyyy-MM-dd HH:mm:ss} UTC.");
     }
 
+    internal static bool TryParseReminderDuration(string input, out double totalSeconds)
+    {
+        Match durationSequence = ReminderDurationSequencePattern.Match(input);
+        totalSeconds = 0;
+
+        if (!durationSequence.Success)
+            return false;
+
+        foreach (Match match in ReminderDurationTokenPattern.Matches(durationSequence.Value))
+        {
+            if (!long.TryParse(match.Groups[1].Value, out long number))
+                continue;
+
+            string unit = match.Groups[2].Value.ToLowerInvariant();
+
+            switch (unit)
+            {
+                case var u when u.StartsWith("y") || u.StartsWith("yr"):
+                    totalSeconds += (double)number * 365 * 24 * 3600; // years -> 365 days
+                    break;
+                case var u when u.StartsWith("mo"):
+                    totalSeconds += (double)number * 30 * 24 * 3600; // months -> 30 days
+                    break;
+                case var u when u.StartsWith("w"):
+                    totalSeconds += (double)number * 7 * 24 * 3600;
+                    break;
+                case var u when u.StartsWith("d"):
+                    totalSeconds += (double)number * 24 * 3600;
+                    break;
+                case var u when u.StartsWith("h"):
+                    totalSeconds += (double)number * 3600;
+                    break;
+                case var u when u.StartsWith("m") && (u == "m" || u.StartsWith("min") || u.StartsWith("mins")):
+                    totalSeconds += (double)number * 60;
+                    break;
+                case var u when u.StartsWith("s"):
+                    totalSeconds += (double)number;
+                    break;
+            }
+        }
+
+        return true;
+    }
+
     internal static string? ExtractReminderText(string input)
     {
-        string text = ReminderDurationSequencePattern.Replace(input, "").Trim();
+        string text = ReminderDurationSequencePattern.Replace(input, "", 1).Trim();
 
         while (LeadingReminderSeparatorPattern.IsMatch(text))
             text = LeadingReminderSeparatorPattern.Replace(text, "").TrimStart();

--- a/Morpheus.Tests/UtilityModuleTests.cs
+++ b/Morpheus.Tests/UtilityModuleTests.cs
@@ -30,9 +30,33 @@ public class UtilityModuleTests
     [InlineData("5 days and remember to buy milk", "and remember to buy milk")]
     [InlineData("5 days and 3 hours and remember to call Alice", "and remember to call Alice")]
     [InlineData("5 days, and remember to buy milk", "and remember to buy milk")]
+    [InlineData("5 minutes remind me in 2 hours", "remind me in 2 hours")]
     [InlineData("5 days and 3 hours", null)]
     public void ExtractReminderText_RemovesDurationSeparators(string input, string? expected)
     {
         Assert.Equal(expected, UtilityModule.ExtractReminderText(input));
+    }
+
+    [Theory]
+    [InlineData("5 minutes remind me in 2 hours", 300)]
+    [InlineData("5 days and 3 hours call Alice", 442800)]
+    [InlineData("5 days, 3 hours call Alice", 442800)]
+    [InlineData("1 hour; 30 minutes check the oven", 5400)]
+    [InlineData("7 weeks 2 minutes check the calendar", 4233720)]
+    public void TryParseReminderDuration_OnlyCountsLeadingDuration(string input, double expectedSeconds)
+    {
+        bool parsed = UtilityModule.TryParseReminderDuration(input, out double totalSeconds);
+
+        Assert.True(parsed);
+        Assert.Equal(expectedSeconds, totalSeconds);
+    }
+
+    [Fact]
+    public void TryParseReminderDuration_RejectsTextBeforeDuration()
+    {
+        bool parsed = UtilityModule.TryParseReminderDuration("Remind me in 2 hours", out double totalSeconds);
+
+        Assert.False(parsed);
+        Assert.Equal(0, totalSeconds);
     }
 }


### PR DESCRIPTION
## Summary
- parse reminder durations only from the leading duration specification
- preserve duration-like phrases that appear later in reminder text
- retain compound duration support for conjunction, punctuation, and whitespace separators

## Verification
- `dotnet build --verbosity minimal` — passed (0 errors; existing NU1903 warning for SQLitePCLRaw.lib.e_sqlite3 2.1.6)
- `dotnet test --no-build --filter 'FullyQualifiedName~Morpheus.Tests.UtilityModuleTests' --verbosity minimal` — passed (17/17)
- `dotnet test --no-build --filter 'FullyQualifiedName!~NormalizeTimeUntilEventName_NormalizesCase' --verbosity minimal` — passed (304/304 applicable tests)
- `dotnet test --no-build --verbosity minimal` — 304/306 passed; the two unrelated failures require `tr-TR`, which this globalization-invariant runner cannot load
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: changes are limited to reminder duration parsing and text extraction, with focused regression coverage.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
