### PR TITLE
fix: stabilize stock mover tie ordering

### DIFF
--- a/Morpheus.Tests/StocksServiceTests.cs
+++ b/Morpheus.Tests/StocksServiceTests.cs
@@ -1,10 +1,45 @@
 using Morpheus.Database.Enums;
+using Morpheus.Database.Models;
 using Morpheus.Services;
 
 namespace Morpheus.Tests;
 
 public class StocksServiceTests
 {
+    [Fact]
+    public void OrderByDailyChange_UsesStockIdToBreakGainerTies()
+    {
+        Stock[] stocks =
+        [
+            new() { Id = 3, DailyChangePercent = 5m },
+            new() { Id = 2, DailyChangePercent = 7m },
+            new() { Id = 1, DailyChangePercent = 7m }
+        ];
+
+        List<int> orderedIds = StocksService.OrderByDailyChange(stocks.AsQueryable(), descending: true)
+            .Select(stock => stock.Id)
+            .ToList();
+
+        Assert.Equal([1, 2, 3], orderedIds);
+    }
+
+    [Fact]
+    public void OrderByDailyChange_UsesStockIdToBreakLoserTies()
+    {
+        Stock[] stocks =
+        [
+            new() { Id = 3, DailyChangePercent = -5m },
+            new() { Id = 2, DailyChangePercent = -7m },
+            new() { Id = 1, DailyChangePercent = -7m }
+        ];
+
+        List<int> orderedIds = StocksService.OrderByDailyChange(stocks.AsQueryable(), descending: false)
+            .Select(stock => stock.Id)
+            .ToList();
+
+        Assert.Equal([1, 2, 3], orderedIds);
+    }
+
     [Fact]
     public void OrderStockHoldingKeysForUpdate_DeduplicatesAndSortsByStockThenUser()
     {

--- a/Services/StocksService.cs
+++ b/Services/StocksService.cs
@@ -483,6 +483,14 @@ public class StocksService(DB dbContext, LogsService logsService, EconomyService
     }
 
     /// <summary>
+    /// Order stocks by daily change, using the stock ID for deterministic ties.
+    /// </summary>
+    internal static IOrderedQueryable<Stock> OrderByDailyChange(IQueryable<Stock> stocks, bool descending) =>
+        descending
+            ? stocks.OrderByDescending(stock => stock.DailyChangePercent).ThenBy(stock => stock.Id)
+            : stocks.OrderBy(stock => stock.DailyChangePercent).ThenBy(stock => stock.Id);
+
+    /// <summary>
     /// Get the top gaining stocks for the current UTC day.
     /// </summary>
     public async Task<List<Stock>> GetTopGainers(int page = 1, int pageSize = 10)
@@ -490,10 +498,9 @@ public class StocksService(DB dbContext, LogsService logsService, EconomyService
         DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow);
         DateTime todayStart = today.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
 
-        return await dbContext.Stocks
+        return await OrderByDailyChange(dbContext.Stocks
             .AsNoTracking()
-            .Where(s => s.LastUpdatedDate >= todayStart && s.DailyChangePercent > 0)
-            .OrderByDescending(s => s.DailyChangePercent)
+            .Where(s => s.LastUpdatedDate >= todayStart && s.DailyChangePercent > 0), descending: true)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
             .ToListAsync();
@@ -520,10 +527,9 @@ public class StocksService(DB dbContext, LogsService logsService, EconomyService
         DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow);
         DateTime todayStart = today.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
 
-        return await dbContext.Stocks
+        return await OrderByDailyChange(dbContext.Stocks
             .AsNoTracking()
-            .Where(s => s.LastUpdatedDate >= todayStart && s.DailyChangePercent < 0)
-            .OrderBy(s => s.DailyChangePercent)
+            .Where(s => s.LastUpdatedDate >= todayStart && s.DailyChangePercent < 0), descending: false)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
             .ToListAsync();
@@ -559,15 +565,14 @@ public class StocksService(DB dbContext, LogsService logsService, EconomyService
             .Where(c => guildChannelDiscordIds.Contains(c.DiscordId))
             .Select(c => c.Id);
 
-        return await dbContext.Stocks
+        return await OrderByDailyChange(dbContext.Stocks
             .AsNoTracking()
             .Where(s => s.LastUpdatedDate >= todayStart && s.DailyChangePercent > 0)
             .Where(s =>
                 (s.EntityType == StockEntityType.Guild && s.EntityId == guildId) ||
                 (s.EntityType == StockEntityType.Channel && validChannelIds.Contains(s.EntityId)) ||
                 (s.EntityType == StockEntityType.User && validUserIds.Contains(s.EntityId))
-            )
-            .OrderByDescending(s => s.DailyChangePercent)
+            ), descending: true)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
             .ToListAsync();
@@ -602,15 +607,14 @@ public class StocksService(DB dbContext, LogsService logsService, EconomyService
         var validUserIds = dbContext.UserActivity.Where(ua => ua.GuildId == guildId).Select(ua => ua.UserId);
         var validChannelIds = dbContext.Channels.Where(c => guildChannelDiscordIds.Contains(c.DiscordId)).Select(c => c.Id);
 
-        return await dbContext.Stocks
+        return await OrderByDailyChange(dbContext.Stocks
             .AsNoTracking()
             .Where(s => s.LastUpdatedDate >= todayStart && s.DailyChangePercent < 0)
             .Where(s =>
                 (s.EntityType == StockEntityType.Guild && s.EntityId == guildId) ||
                 (s.EntityType == StockEntityType.Channel && validChannelIds.Contains(s.EntityId)) ||
                 (s.EntityType == StockEntityType.User && validUserIds.Contains(s.EntityId))
-            )
-            .OrderBy(s => s.DailyChangePercent)
+            ), descending: false)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
             .ToListAsync();
@@ -644,15 +648,13 @@ public class StocksService(DB dbContext, LogsService logsService, EconomyService
         DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow);
         DateTime todayStart = today.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
 
-        var gainers = await dbContext.Stocks
-            .Where(s => s.LastUpdatedDate >= todayStart && s.DailyChangePercent > 0)
-            .OrderByDescending(s => s.DailyChangePercent)
+        var gainers = await OrderByDailyChange(dbContext.Stocks
+            .Where(s => s.LastUpdatedDate >= todayStart && s.DailyChangePercent > 0), descending: true)
             .Take(count)
             .ToListAsync();
 
-        var losers = await dbContext.Stocks
-            .Where(s => s.LastUpdatedDate >= todayStart && s.DailyChangePercent < 0)
-            .OrderBy(s => s.DailyChangePercent)
+        var losers = await OrderByDailyChange(dbContext.Stocks
+            .Where(s => s.LastUpdatedDate >= todayStart && s.DailyChangePercent < 0), descending: false)
             .Take(count)
             .ToListAsync();
 


### PR DESCRIPTION
## Summary
- add stock IDs as deterministic tie-breakers for global and guild-scoped gainers/losers
- apply the same stable ordering to top-mover snapshots
- add regression tests for tied positive and negative daily changes

## Verification
- `dotnet build` — passed (known `SQLitePCLRaw.lib.e_sqlite3` vulnerability warning remains)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter FullyQualifiedName~StocksServiceTests` — passed, 5/5
- `dotnet test --filter 'FullyQualifiedName!~MiscModuleTests.NormalizeTimeUntilEventName_NormalizesCase'` — passed, 299/299 applicable tests
- `dotnet test` — 299 passed, 2 failed because this runner lacks `tr-TR` globalization support
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: only equal daily-change values gain a stable stock-ID order; filters and primary ordering are unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
