### PR TITLE
fix: accept multi-word Urban Dictionary terms

### DIFF
--- a/Modules/MiscModule.cs
+++ b/Modules/MiscModule.cs
@@ -535,7 +535,7 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
     [Command("udic")]
     [Alias("urbandictionary", "urbandic", "udictionary")]
     [RateLimit(5, 30)]
-    public async Task UrbanDictionary(string? word = null)
+    public async Task UrbanDictionary([Remainder] string? word = null)
     {
         string url = BuildUrbanDictionaryUrl(word);
 

--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Reflection;
 using Discord.Commands;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -107,6 +108,20 @@ public class MiscModuleTests
         string result = MiscModule.BuildUrbanDictionaryUrl("C# & tea");
 
         Assert.Equal("https://api.urbandictionary.com/v0/define?term=C%23%20%26%20tea", result);
+    }
+
+    [Fact]
+    public void UrbanDictionaryCommand_AcceptsMultiWordTerms()
+    {
+        MethodInfo method = Assert.Single(
+            typeof(MiscModule).GetMethods(),
+            method => method.GetCustomAttributes<CommandAttribute>()
+                .Any(attribute => attribute.Text == "udic"));
+        System.Reflection.ParameterInfo parameter = Assert.Single(method.GetParameters());
+
+        Assert.NotNull(parameter.GetCustomAttribute<RemainderAttribute>());
+        Assert.True(parameter.HasDefaultValue);
+        Assert.Null(parameter.DefaultValue);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- allow `udic` and its aliases to consume the full remaining command text so multi-word Urban Dictionary terms are accepted
- add a regression test for the command parameter metadata while preserving the optional random-definition behavior

## Verification
- `dotnet build` — passed with 0 errors (existing SQLitePCLRaw vulnerability warning remains)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~UrbanDictionaryCommand_AcceptsMultiWordTerms --no-restore` — passed, 1/1
- `dotnet test --no-restore --filter 'FullyQualifiedName!~NormalizeTimeUntilEventName_NormalizesCase'` — passed, 298/298
- `dotnet test` — 298 passed and 2 unrelated tests failed because this runner lacks ICU and cannot load `tr-TR`
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change restores Discord.Net remainder parsing on one optional string parameter and is covered by a focused registration test.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
