### PR TITLE
fix: prevent level command XP overflow

### DIFF
--- a/Handlers/ActivityHandler.cs
+++ b/Handlers/ActivityHandler.cs
@@ -195,4 +195,9 @@ public class ActivityHandler
     {
         return ActivityLevelService.CalculateXp(level);
     }
+
+    public static long CalculateXpLong(int level)
+    {
+        return ActivityLevelService.CalculateXpLong(level);
+    }
 }

--- a/Modules/LevelsModule.cs
+++ b/Modules/LevelsModule.cs
@@ -45,9 +45,9 @@ public class LevelsModule(
             return;
         }
 
-        long totalXp = userLevels.Sum(ul => ul.TotalXp);
+        long totalXp = SumTotalXp(userLevels);
         int totalLevel = ActivityHandler.CalculateLevel(totalXp);
-        long totalXpNeededForNextLevel = ActivityHandler.CalculateXp(totalLevel + 1);
+        long totalXpNeededForNextLevel = ActivityHandler.CalculateXpLong(totalLevel + 1);
 
         await ReplyAsync($"**Global**: Level **{totalLevel}** with **{totalXp}** XP");
         await ReplyAsync($"**{totalXpNeededForNextLevel - totalXp}** XP needed to level up globally \n");
@@ -56,12 +56,15 @@ public class LevelsModule(
         {
             await ReplyAsync($"**{guild.Name}**: Level **{userLevelGuild.Level}** with **{userLevelGuild.TotalXp}** XP");
 
-            totalXpNeededForNextLevel = ActivityHandler.CalculateXp(userLevelGuild.Level + 1);
+            totalXpNeededForNextLevel = ActivityHandler.CalculateXpLong(userLevelGuild.Level + 1);
 
             await ReplyAsync($"**{totalXpNeededForNextLevel - userLevelGuild.TotalXp}** XP needed to level up");
             return;
         }
     }
+
+    internal static long SumTotalXp(IQueryable<UserLevels> userLevels) =>
+        userLevels.Sum(ul => (long)ul.TotalXp);
 
     [Name("Activity Graph")]
     [Summary("Generates an activity graph for the top 10 users over the past n days.")]

--- a/Morpheus.Tests/ActivityLevelServiceTests.cs
+++ b/Morpheus.Tests/ActivityLevelServiceTests.cs
@@ -49,4 +49,28 @@ public class ActivityLevelServiceTests
 
         Assert.Throws<OverflowException>(() => ActivityLevelService.CalculateXp(highestRepresentableLevel + 1));
     }
+
+    [Fact]
+    public void CalculateXpLong_ReturnsThresholdAboveIntMaxValue()
+    {
+        int level = ActivityLevelService.CalculateLevel((long)int.MaxValue + 1) + 1;
+
+        long threshold = ActivityLevelService.CalculateXpLong(level);
+
+        Assert.True(threshold > int.MaxValue);
+        Assert.Equal(level, ActivityLevelService.CalculateLevel(threshold));
+        Assert.True(ActivityLevelService.CalculateLevel(threshold - 1) < level);
+    }
+
+    [Fact]
+    public void CalculateXpLong_HandlesHighestRepresentableLongLevel()
+    {
+        int highestRepresentableLevel = ActivityLevelService.CalculateLevel(long.MaxValue);
+
+        long threshold = ActivityLevelService.CalculateXpLong(highestRepresentableLevel);
+
+        Assert.Equal(highestRepresentableLevel, ActivityLevelService.CalculateLevel(threshold));
+        Assert.True(ActivityLevelService.CalculateLevel(threshold - 1) < highestRepresentableLevel);
+        Assert.Throws<OverflowException>(() => ActivityLevelService.CalculateXpLong(highestRepresentableLevel + 1));
+    }
 }

--- a/Morpheus.Tests/LevelsModuleTests.cs
+++ b/Morpheus.Tests/LevelsModuleTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class LevelsModuleTests
+{
+    [Fact]
+    public async Task SumTotalXp_ReturnsLongTotalWhenGuildXpExceedsIntMaxValue()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        User user = new() { DiscordId = 1, Username = "user" };
+        Guild firstGuild = new() { DiscordId = 1, Name = "First guild" };
+        Guild secondGuild = new() { DiscordId = 2, Name = "Second guild" };
+        db.AddRange(user, firstGuild, secondGuild);
+        await db.SaveChangesAsync();
+
+        db.UserLevels.AddRange(
+            new UserLevels { UserId = user.Id, GuildId = firstGuild.Id, TotalXp = int.MaxValue },
+            new UserLevels { UserId = user.Id, GuildId = secondGuild.Id, TotalXp = 1 });
+        await db.SaveChangesAsync();
+
+        IQueryable<UserLevels> userLevels = db.UserLevels.Where(level => level.UserId == user.Id);
+
+        long totalXp = LevelsModule.SumTotalXp(userLevels);
+
+        Assert.Equal((long)int.MaxValue + 1, totalXp);
+    }
+}

--- a/Services/ActivityLevelService.cs
+++ b/Services/ActivityLevelService.cs
@@ -68,41 +68,45 @@ public class ActivityLevelService(DB dbContext)
 
     public static int CalculateLevel(long xp)
     {
-        return (int)Math.Pow(Math.Log10((xp + 111) / 111), 5.0243);
+        long normalizedXp = xp > long.MaxValue - 111
+            ? (xp / 111) + 1
+            : (xp + 111) / 111;
+
+        return (int)Math.Pow(Math.Log10(normalizedXp), 5.0243);
     }
 
     public static int CalculateXp(int level)
     {
+        long xp = CalculateXpLong(level);
+
+        if (xp > int.MaxValue)
+            throw new OverflowException($"Level {level} requires more XP than can be represented as an integer.");
+
+        return (int)xp;
+    }
+
+    public static long CalculateXpLong(int level)
+    {
         if (level <= 0)
             return 0;
 
-        long estimate = Math.Max(0, (long)Math.Floor(111 * Math.Pow(10, Math.Pow(level, 1.0 / 5.0243)) - 111));
-        long lower = Math.Max(0, estimate - 111);
-        long upper = Math.Max(estimate + 111, 1);
+        if (CalculateLevel(long.MaxValue) < level)
+            throw new OverflowException($"Level {level} requires more XP than can be represented as a long integer.");
 
-        while (CalculateLevel(upper) < level)
-        {
-            lower = upper;
-            upper *= 2;
+        long lower = 0;
+        long upper = long.MaxValue;
 
-            if (upper > int.MaxValue)
-                throw new OverflowException($"Level {level} requires more XP than can be represented as an integer.");
-        }
-
-        if (upper > int.MaxValue)
-            throw new OverflowException($"Level {level} requires more XP than can be represented as an integer.");
-
-        while (lower + 1 < upper)
+        while (lower < upper)
         {
             long midpoint = lower + ((upper - lower) / 2);
 
             if (CalculateLevel(midpoint) >= level)
                 upper = midpoint;
             else
-                lower = midpoint;
+                lower = midpoint + 1;
         }
 
-        return (int)upper;
+        return lower;
     }
 
     private static void ApplyActivityToUserLevel(UserLevels userLevel, UserActivity activity)


### PR DESCRIPTION
## Summary
- sum per-guild XP as `long` so the global level command does not overflow above `int.MaxValue`
- add long-range next-level threshold calculation while preserving the existing `int` API
- cover EF aggregate translation and `long` boundary behavior with regression tests

## Verification
- `dotnet build` — passed with 0 errors (existing SQLitePCLRaw vulnerability warning remains)
- `dotnet test --filter 'FullyQualifiedName~LevelsModuleTests|FullyQualifiedName~ActivityLevelServiceTests'` — passed, 14/14
- `dotnet test` — 300/302 passed; two existing `MiscModuleTests` fail because this runner's invariant-globalization mode cannot load `tr-TR`
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change is limited to level/XP arithmetic and regression tests; existing integer callers retain the same API and overflow contract.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
