### PR TITLE
test: skip unavailable culture regression

### DIFF
--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -7,6 +7,21 @@ using Morpheus.Modules;
 
 namespace Morpheus.Tests;
 
+public sealed class SupportedCultureTheoryAttribute : TheoryAttribute
+{
+    public SupportedCultureTheoryAttribute(string cultureName)
+    {
+        try
+        {
+            CultureInfo.GetCultureInfo(cultureName);
+        }
+        catch (CultureNotFoundException)
+        {
+            Skip = $"The {cultureName} culture is unavailable in globalization-invariant mode.";
+        }
+    }
+}
+
 public class MiscModuleTests
 {
     [Theory]
@@ -31,7 +46,7 @@ public class MiscModuleTests
         Assert.Equal(new DateTime(expectedYear, eventMonth, eventDay, 0, 0, 0, DateTimeKind.Utc), result);
     }
 
-    [Theory]
+    [SupportedCultureTheory("tr-TR")]
     [InlineData("CHRISTMAS", "christmas")]
     [InlineData("CC BIRTHDAY", "cc birthday")]
     public void NormalizeTimeUntilEventName_NormalizesCase(string eventName, string expected)


### PR DESCRIPTION
## Summary
- add a culture-aware xUnit theory attribute that explicitly skips tests when their required culture is unavailable
- preserve the Turkish-casing regression test when `tr-TR` is supported while allowing globalization-invariant test runs to complete

## Verification
- `dotnet test --filter 'FullyQualifiedName~MiscModuleTests.NormalizeTimeUntilEventName_NormalizesCase' --logger 'console;verbosity=normal'` — passed: the unsupported culture was reported as one explicit skip
- `dotnet build` — passed with the existing SQLitePCLRaw NU1903 advisory warning
- `dotnet test --no-build` — passed: 297 passed, 1 skipped, 0 failed
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: test-only behavior; the Turkish regression still runs unchanged where that culture is available.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
