### PR TITLE
fix: preserve thin image dimensions when resizing

### DIFF
--- a/Morpheus.Tests/ImageResizerTests.cs
+++ b/Morpheus.Tests/ImageResizerTests.cs
@@ -1,0 +1,32 @@
+using Morpheus.Utilities.Images;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Morpheus.Tests;
+
+public class ImageResizerTests
+{
+    [Theory]
+    [InlineData(1, 10000, 1, 3840)]
+    [InlineData(10000, 1, 3840, 1)]
+    public void DownscaleIfTooLarge_PreservesAtLeastOnePixelPerDimension(
+        int width,
+        int height,
+        int expectedWidth,
+        int expectedHeight)
+    {
+        byte[] input;
+        using (Image<Rgba32> image = new(width, height, new Rgba32(255, 0, 0)))
+        using (MemoryStream stream = new())
+        {
+            image.SaveAsPng(stream);
+            input = stream.ToArray();
+        }
+
+        byte[] output = ImageResizer.DownscaleIfTooLarge(input);
+
+        using Image<Rgba32> resized = Image.Load<Rgba32>(output);
+        Assert.Equal(expectedWidth, resized.Width);
+        Assert.Equal(expectedHeight, resized.Height);
+    }
+}

--- a/Utilities/Images/ImageResizer.cs
+++ b/Utilities/Images/ImageResizer.cs
@@ -24,8 +24,8 @@ public static class ImageResizer
         using Image<Rgba32> image = Image.Load<Rgba32>(ms);
 
         float scale = Math.Min((float)MaxDimension / info.Width, (float)MaxDimension / info.Height);
-        int newWidth = (int)(info.Width * scale);
-        int newHeight = (int)(info.Height * scale);
+        int newWidth = Math.Max(1, (int)(info.Width * scale));
+        int newHeight = Math.Max(1, (int)(info.Height * scale));
 
         image.Mutate(x => x.Resize(newWidth, newHeight));
 


### PR DESCRIPTION
## Summary
- prevent extreme-aspect-ratio images from rounding a resized dimension down to zero
- add horizontal and vertical regression coverage for thin images

## Verification
- `dotnet build --no-restore` — passed with the existing SQLitePCLRaw vulnerability warning
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~ImageResizerTests --no-restore --verbosity minimal` — passed (2/2)
- `dotnet test --no-build --no-restore --verbosity minimal` — 299 passed, 2 failed because this runner's globalization-invariant mode cannot load `tr-TR` in the pre-existing `MiscModuleTests` cases (tracked by #81)
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- low: the clamp only affects resize calculations that would otherwise produce an invalid zero-pixel dimension

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
