### PR TITLE
fix: trim timeuntil event names

### DIFF
--- a/Modules/MiscModule.cs
+++ b/Modules/MiscModule.cs
@@ -124,7 +124,7 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
         return eventDate < now ? eventDate.AddYears(1) : eventDate;
     }
 
-    internal static string NormalizeTimeUntilEventName(string eventName) => eventName.ToLowerInvariant();
+    internal static string NormalizeTimeUntilEventName(string eventName) => eventName.Trim().ToLowerInvariant();
 
     [Name("Coin Flip")]
     [Summary("Flips a coin, or multiple coins.")]

--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -51,6 +51,14 @@ public class MiscModuleTests
     }
 
     [Theory]
+    [InlineData("  christmas  ", "christmas")]
+    [InlineData("\tcc birthday\r\n", "cc birthday")]
+    public void NormalizeTimeUntilEventName_TrimsSurroundingWhitespace(string eventName, string expected)
+    {
+        Assert.Equal(expected, MiscModule.NormalizeTimeUntilEventName(eventName));
+    }
+
+    [Theory]
     [InlineData("ROCK", "rock")]
     [InlineData("PaPeR", "paper")]
     [InlineData("ScIsSoRs", "scissors")]


### PR DESCRIPTION
## Summary
- trim surrounding whitespace before matching `timeuntil` event names, so padded valid names are accepted
- add regression coverage for spaces, tabs, and line endings around event names

## Verification
- `dotnet build --no-restore` — passed (1 existing NU1903 package advisory warning)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter FullyQualifiedName~NormalizeTimeUntilEventName_TrimsSurroundingWhitespace --verbosity minimal` — passed, 2/2
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter 'FullyQualifiedName!~NormalizeTimeUntilEventName_NormalizesCase' --verbosity minimal` — passed, 299/299
- `dotnet test --no-restore --verbosity minimal` — 299 passed, 2 failed because the existing Turkish-culture test cannot load `tr-TR` in globalization-invariant mode (tracked by open PR #81)
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: normalization now removes only surrounding whitespace before the existing invariant case conversion; internal whitespace and supported aliases are unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
