### PR TITLE
fix: prevent global message count overflow

### DIFF
--- a/Morpheus.Tests/ActivityLeaderboardServiceTests.cs
+++ b/Morpheus.Tests/ActivityLeaderboardServiceTests.cs
@@ -110,6 +110,57 @@ public class ActivityLeaderboardServiceTests
     }
 
     [Fact]
+    public async Task GetGlobalMessageLeaderboardAsync_SupportsTotalsLargerThanIntMaxValue()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        User activeUser = new() { DiscordId = 1, Username = "active" };
+        User otherUser = new() { DiscordId = 2, Username = "other" };
+        Guild firstGuild = new() { DiscordId = 1, Name = "First guild" };
+        Guild secondGuild = new() { DiscordId = 2, Name = "Second guild" };
+        db.AddRange(activeUser, otherUser, firstGuild, secondGuild);
+        await db.SaveChangesAsync();
+
+        db.UserLevels.AddRange(
+            new UserLevels
+            {
+                UserId = activeUser.Id,
+                GuildId = firstGuild.Id,
+                UserMessageCount = int.MaxValue
+            },
+            new UserLevels
+            {
+                UserId = activeUser.Id,
+                GuildId = secondGuild.Id,
+                UserMessageCount = 1
+            },
+            new UserLevels
+            {
+                UserId = otherUser.Id,
+                GuildId = firstGuild.Id,
+                UserMessageCount = 1
+            });
+        await db.SaveChangesAsync();
+
+        ActivityLeaderboardService service = new(db);
+        ActivityLeaderboardQueryResult result = await service.GetGlobalMessageLeaderboardAsync(
+            activeUser.Id,
+            page: 1);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Page);
+        Assert.Equal("[1] | active: Messages 2147483648", result.Page.Lines[0]);
+        Assert.Equal("Your rank: #1", result.Page.RankLine);
+    }
+
+    [Fact]
     public async Task GetGuildXpLeaderboardAsync_OrdersTiesByUserIdAcrossPages()
     {
         await using SqliteConnection connection = new("Data Source=:memory:");

--- a/Services/ActivityLeaderboardService.cs
+++ b/Services/ActivityLeaderboardService.cs
@@ -203,7 +203,7 @@ public class ActivityLeaderboardService(DB dbContext)
         var query = dbContext.UserLevels
             .AsNoTracking()
             .GroupBy(ul => ul.UserId)
-            .Select(g => new { UserId = g.Key, Value = g.Sum(ul => ul.UserMessageCount) })
+            .Select(g => new { UserId = g.Key, Value = g.Sum(ul => (long)ul.UserMessageCount) })
             .Where(x => x.Value > 0)
             .OrderByDescending(x => x.Value)
             .ThenBy(x => x.UserId);
@@ -388,7 +388,7 @@ public class ActivityLeaderboardService(DB dbContext)
         return $"[{GetRankNumber(page, index)}] | {name}: Level {ActivityLevelService.CalculateLevel(xp)} with {xp} XP";
     }
 
-    private static string FormatMessageLine(int userId, IReadOnlyDictionary<int, string> names, int count, int page, int index)
+    private static string FormatMessageLine(int userId, IReadOnlyDictionary<int, string> names, long count, int page, int index)
     {
         string name = names.TryGetValue(userId, out string? username) ? username : userId.ToString();
         return $"[{GetRankNumber(page, index)}] | {name}: Messages {count}";
@@ -509,7 +509,7 @@ public class ActivityLeaderboardService(DB dbContext)
         int better = await dbContext.UserLevels
             .AsNoTracking()
             .GroupBy(ul => ul.UserId)
-            .Select(g => new { Count = g.Sum(ul => ul.UserMessageCount) })
+            .Select(g => new { Count = g.Sum(ul => (long)ul.UserMessageCount) })
             .CountAsync(x => x.Count > myCount);
 
         return $"Your rank: #{better + 1}";


### PR DESCRIPTION
## Summary
- widen global message-count aggregation and rank comparisons to 64-bit totals
- add a SQLite regression test covering a cross-guild total above `int.MaxValue`

## Verification
- `dotnet build --no-restore` — passed with one existing package-vulnerability warning
- `dotnet test --no-build --no-restore --filter FullyQualifiedName!~NormalizeTimeUntilEventName_NormalizesCase` — passed, 298/298
- `dotnet test --no-build --no-restore` — 298 passed, 2 failed because this runner uses globalization-invariant mode and cannot load `tr-TR`
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: changes only the numeric width used by existing global message leaderboard queries and formatting.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.