### PR TITLE
fix: refresh guild names after server renames

### DIFF
--- a/Morpheus.Tests/GuildServiceTests.cs
+++ b/Morpheus.Tests/GuildServiceTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Morpheus.Database;
+using Morpheus.Database.Models;
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class GuildServiceTests
+{
+    [Fact]
+    public async Task TryGetCreateGuild_UpdatesStoredNameForExistingGuild()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        Guild guild = new()
+        {
+            DiscordId = 123,
+            Name = "old-name"
+        };
+        await db.Guilds.AddAsync(guild);
+        await db.SaveChangesAsync();
+
+        using ServiceProvider services = new ServiceCollection().BuildServiceProvider();
+        GuildPrefixService prefixService = new(services.GetRequiredService<IServiceScopeFactory>());
+        GuildService service = new(db, new LogsService(new LogQueue()), prefixService);
+
+        Guild result = await service.TryGetCreateGuild(123, "new-name");
+
+        Assert.Equal("new-name", result.Name);
+
+        db.ChangeTracker.Clear();
+        Guild persisted = await db.Guilds.SingleAsync(g => g.DiscordId == 123);
+        Assert.Equal("new-name", persisted.Name);
+    }
+}

--- a/Services/GuildService.cs
+++ b/Services/GuildService.cs
@@ -6,25 +6,36 @@ using Morpheus.Database.Models;
 namespace Morpheus.Services;
 public class GuildService(DB dbContext, LogsService logsService, GuildPrefixService guildPrefixService)
 {
-    public async Task<Guild> TryGetCreateGuild(SocketGuild guild)
+    public Task<Guild> TryGetCreateGuild(SocketGuild guild) =>
+        TryGetCreateGuild(guild.Id, guild.Name);
+
+    internal async Task<Guild> TryGetCreateGuild(ulong discordId, string name)
     {
-        Guild? guildDb = await dbContext.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guild.Id);
+        Guild? guildDb = await dbContext.Guilds.FirstOrDefaultAsync(g => g.DiscordId == discordId);
 
         if (guildDb != null)
+        {
+            if (guildDb.Name != name)
+            {
+                guildDb.Name = name;
+                await dbContext.SaveChangesAsync();
+            }
+
             return guildDb;
+        }
 
         guildDb = new Guild
         {
-            DiscordId = guild.Id,
-            Name = guild.Name,
+            DiscordId = discordId,
+            Name = name,
             Prefix = guildPrefixService.DefaultPrefix
         };
 
         await dbContext.Guilds.AddAsync(guildDb);
         await dbContext.SaveChangesAsync();
 
-        logsService.Log($"New guild created {guild.Name}", Discord.LogSeverity.Verbose);
-        guildPrefixService.SetPrefix(guild.Id, guildDb.Prefix);
+        logsService.Log($"New guild created {name}", Discord.LogSeverity.Verbose);
+        guildPrefixService.SetPrefix(discordId, guildDb.Prefix);
 
         return guildDb;
     }


### PR DESCRIPTION
## Summary
- refresh the persisted Discord guild name when an existing server is renamed
- add a SQLite regression test covering both the returned and persisted guild record

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter FullyQualifiedName~GuildServiceTests` — passed (1/1)
- `dotnet build --no-restore` — passed with the existing SQLitePCLRaw vulnerability warning
- `dotnet test --no-restore` — 298 passed, 2 failed because this runner uses invariant globalization and cannot load `tr-TR`; the unrelated portable-culture fix is already tracked in #81
- `git diff --check` — passed

## Risk
- Low: the change only writes when a stored guild name differs, matching the existing channel-name refresh behavior.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
