### PR TITLE
fix: chunk oversized log messages

### DIFF
--- a/Modules/AdministratorModule.cs
+++ b/Modules/AdministratorModule.cs
@@ -58,24 +58,8 @@ public class AdministratorModule(DiscordSocketClient client, DB dbContext) : Mod
             lines.Add($"[{time}] (v{log.Version}) [Severity:{log.Severity}] {log.Message}");
         }
 
-        const int maxMessageSize = 1900; // leave room for code fences
-        var sb = new StringBuilder();
-
-        foreach (var line in lines)
-        {
-            if (sb.Length + line.Length + 4 > maxMessageSize) // send current chunk
-            {
-                await ReplyAsync("```\n" + sb.ToString().TrimEnd() + "\n```");
-                sb.Clear();
-            }
-
-            sb.AppendLine(line);
-        }
-
-        if (sb.Length > 0)
-        {
-            await ReplyAsync("```\n" + sb.ToString().TrimEnd() + "\n```");
-        }
+        foreach (string message in BuildLogMessages(lines))
+            await ReplyAsync(message);
     }
 
     [Name("Guild Count")]
@@ -166,5 +150,68 @@ public class AdministratorModule(DiscordSocketClient client, DB dbContext) : Mod
     {
         ownerId = 0;
         return !string.IsNullOrWhiteSpace(value) && ulong.TryParse(value, out ownerId);
+    }
+
+    internal static IReadOnlyList<string> BuildLogMessages(IEnumerable<string> lines)
+    {
+        const string prefix = "```\n";
+        const string suffix = "\n```";
+        const int maxMessageLength = 2000;
+        int maxContentLength = maxMessageLength - prefix.Length - suffix.Length;
+
+        var messages = new List<string>();
+        var chunk = new StringBuilder();
+
+        void Flush()
+        {
+            if (chunk.Length == 0)
+                return;
+
+            messages.Add(prefix + chunk + suffix);
+            chunk.Clear();
+        }
+
+        foreach (string line in lines)
+        {
+            int offset = 0;
+
+            while (offset < line.Length)
+            {
+                int separatorLength = chunk.Length > 0 ? 1 : 0;
+                int available = maxContentLength - chunk.Length - separatorLength;
+
+                if (available <= 0)
+                {
+                    Flush();
+                    continue;
+                }
+
+                int take = Math.Min(available, line.Length - offset);
+                if (offset + take < line.Length
+                    && char.IsHighSurrogate(line[offset + take - 1])
+                    && char.IsLowSurrogate(line[offset + take]))
+                {
+                    take--;
+                }
+
+                if (take == 0)
+                {
+                    Flush();
+                    continue;
+                }
+
+                if (separatorLength > 0)
+                    chunk.Append('\n');
+
+                chunk.Append(line.AsSpan(offset, take));
+                offset += take;
+
+                if (offset < line.Length)
+                    Flush();
+            }
+        }
+
+        Flush();
+        return messages;
     }
 }

--- a/Morpheus.Tests/AdministratorModuleTests.cs
+++ b/Morpheus.Tests/AdministratorModuleTests.cs
@@ -20,4 +20,65 @@ public class AdministratorModuleTests
         Assert.True(AdministratorModule.TryParseOwnerId("123456789012345678", out ulong ownerId));
         Assert.Equal(123456789012345678UL, ownerId);
     }
+
+    [Fact]
+    public void BuildLogMessages_SplitsOversizedLinesWithinDiscordLimit()
+    {
+        string line = new('x', 2000);
+
+        IReadOnlyList<string> messages = AdministratorModule.BuildLogMessages([line]);
+
+        Assert.Equal(2, messages.Count);
+        Assert.All(messages, message => Assert.InRange(message.Length, 1, 2000));
+        Assert.Equal(line, string.Concat(messages.Select(UnwrapCodeBlock)));
+    }
+
+    [Fact]
+    public void BuildLogMessages_GroupsLinesInOrder()
+    {
+        IReadOnlyList<string> messages = AdministratorModule.BuildLogMessages(["first", "second"]);
+
+        Assert.Equal(["```\nfirst\nsecond\n```"], messages);
+    }
+
+    [Fact]
+    public void BuildLogMessages_UsesEntireMessageAtPayloadBoundary()
+    {
+        string line = new('x', 1992);
+
+        string message = Assert.Single(AdministratorModule.BuildLogMessages([line]));
+
+        Assert.Equal(2000, message.Length);
+        Assert.Equal(line, UnwrapCodeBlock(message));
+    }
+
+    [Fact]
+    public void BuildLogMessages_StartsNewChunkAfterPayloadBoundary()
+    {
+        string fullLine = new('x', 1992);
+
+        IReadOnlyList<string> messages = AdministratorModule.BuildLogMessages([fullLine, "next"]);
+
+        Assert.Equal(2, messages.Count);
+        Assert.Equal(fullLine, UnwrapCodeBlock(messages[0]));
+        Assert.Equal("next", UnwrapCodeBlock(messages[1]));
+    }
+
+    [Fact]
+    public void BuildLogMessages_DoesNotSplitSurrogatePairs()
+    {
+        string line = new string('x', 1991) + "😀tail";
+
+        IReadOnlyList<string> messages = AdministratorModule.BuildLogMessages([line]);
+        string[] payloads = messages.Select(UnwrapCodeBlock).ToArray();
+
+        Assert.Equal(line, string.Concat(payloads));
+        Assert.All(payloads, payload =>
+        {
+            Assert.False(char.IsHighSurrogate(payload[^1]));
+            Assert.False(char.IsLowSurrogate(payload[0]));
+        });
+    }
+
+    private static string UnwrapCodeBlock(string message) => message[4..^4];
 }


### PR DESCRIPTION
## Summary
- prevent `dumplogs` from sending empty or over-2,000-character Discord messages when a stored log entry is oversized
- preserve log text and ordering while splitting long lines safely, including at UTF-16 surrogate-pair boundaries
- add regression coverage for oversized lines, exact boundaries, ordering, and emoji boundaries

## Verification
- `dotnet build` — passed (0 errors; existing NU1903 SQLite package warning)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~AdministratorModuleTests` — passed (10/10)
- `dotnet test` — 302 passed, 2 failed because this environment runs in invariant-globalization mode and the existing `tr-tr` culture cases cannot be created
- `git diff --check` — passed

## Risk
- Low: the change is limited to owner-only log output chunking and pure unit-tested formatting logic.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
