### PR TITLE
fix: synchronize random bag access

### DIFF
--- a/Morpheus.Tests/RandomBagTests.cs
+++ b/Morpheus.Tests/RandomBagTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Concurrent;
+
+namespace Morpheus.Tests;
+
+public class RandomBagTests
+{
+    [Fact]
+    public async Task Random_PreservesBagCyclesDuringConcurrentCalls()
+    {
+        string[] items = ["alpha", "beta", "gamma", "delta"];
+        const int workerCount = 8;
+        const int cyclesPerWorker = 250;
+        var bag = new RandomBag([.. items]);
+        var results = new ConcurrentBag<string>();
+        int readyWorkers = 0;
+        var readyGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task[] workers = Enumerable.Range(0, workerCount)
+            .Select(_ => Task.Run(async () =>
+            {
+                if (Interlocked.Increment(ref readyWorkers) == workerCount)
+                    readyGate.SetResult();
+
+                await startGate.Task;
+
+                for (int cycle = 0; cycle < cyclesPerWorker; cycle++)
+                {
+                    foreach (string ignored in items)
+                        results.Add(bag.Random());
+                }
+            }))
+            .ToArray();
+
+        await readyGate.Task;
+        startGate.SetResult();
+        await Task.WhenAll(workers);
+
+        int expectedCountPerItem = workerCount * cyclesPerWorker;
+        Assert.Equal(expectedCountPerItem * items.Length, results.Count);
+        foreach (string item in items)
+            Assert.Equal(expectedCountPerItem, results.Count(result => result == item));
+    }
+}

--- a/Utilities/RandomBag.cs
+++ b/Utilities/RandomBag.cs
@@ -3,6 +3,7 @@
     private readonly List<string> items;
     private readonly List<string> currentBag;
     private readonly Random random;
+    private readonly Lock bagLock = new();
 
     public RandomBag(List<string> initialItems)
     {
@@ -16,19 +17,22 @@
 
     public string Random()
     {
-        if (currentBag.Count == 0)
+        lock (bagLock)
         {
-            // Refill the bag with all items when the current bag is empty
-            currentBag.AddRange(items);
+            if (currentBag.Count == 0)
+            {
+                // Refill the bag with all items when the current bag is empty
+                currentBag.AddRange(items);
+            }
+
+            // Pick a random index from the current bag
+            int index = random.Next(currentBag.Count);
+
+            // Remove the selected item from the bag and return it
+            string selectedItem = currentBag[index];
+            currentBag.RemoveAt(index);
+
+            return selectedItem;
         }
-
-        // Pick a random index from the current bag
-        int index = random.Next(currentBag.Count);
-
-        // Remove the selected item from the bag and return it
-        string selectedItem = currentBag[index];
-        currentBag.RemoveAt(index);
-
-        return selectedItem;
     }
 }


### PR DESCRIPTION
## Summary
- serialize `RandomBag` refill, selection, and removal so concurrent Discord events cannot race its mutable state
- add a synchronized-start concurrency regression test that verifies complete bag cycles preserve every item

## Verification
- `dotnet build` — passed (0 errors; existing SQLite package vulnerability warning remains)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~RandomBagTests --no-restore` — passed (1/1)
- `dotnet test --no-build` — partial: 298 passed, 2 failed because `tr-TR` is unavailable in globalization-invariant mode; the same two failures reproduce on `develop` and are already addressed by #81
- `git diff --check` — passed

## Risk
- Low: locking is limited to each in-memory bag's short refill/select/remove critical section; no command, database, or configuration behavior changes.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
