### PR TITLE
fix: preserve Unicode when truncating quotes

### DIFF
--- a/Morpheus.Tests/QuoteServiceTests.cs
+++ b/Morpheus.Tests/QuoteServiceTests.cs
@@ -80,6 +80,27 @@ public class QuoteServiceTests
     }
 
     [Fact]
+    public void FormatQuoteListFieldValue_DoesNotSplitSurrogatePairsWhenTruncating()
+    {
+        QuoteListItem item = new(
+            Id: 1,
+            GuildId: 1,
+            UserId: 1,
+            Content: new string('x', 296) + "😀" + new string('x', 10),
+            InsertDate: new DateTime(2026, 5, 30, 12, 0, 0, DateTimeKind.Utc),
+            Approved: true,
+            Removed: false,
+            Score: 0,
+            Author: "author");
+
+        string fieldValue = QuoteService.FormatQuoteListFieldValue(item);
+
+        string firstLine = fieldValue.Split('\n')[0];
+        Assert.Equal(new string('x', 296) + "...", firstLine);
+        Assert.False(char.IsSurrogate(firstLine[^4]));
+    }
+
+    [Fact]
     public void GetPreviousPeriodBounds_ReturnsPreviousMonthWindow()
     {
         DateTime now = new(2026, 5, 30, 12, 0, 0, DateTimeKind.Utc);

--- a/Services/QuoteService.cs
+++ b/Services/QuoteService.cs
@@ -514,7 +514,14 @@ public class QuoteService(DB dbContext)
         if (content.Length <= maxLength)
             return content;
 
-        return content[..(maxLength - 3)] + "...";
+        int contentLength = maxLength - 3;
+        if (char.IsHighSurrogate(content[contentLength - 1]) &&
+            char.IsLowSurrogate(content[contentLength]))
+        {
+            contentLength--;
+        }
+
+        return content[..contentLength] + "...";
     }
 
     private async Task<Quote?> FindApprovedQuoteByContentAsync(string quoteContent, int guildId, bool useGlobalQuotes)


### PR DESCRIPTION
## Summary
- avoid cutting a UTF-16 surrogate pair when quote-list content reaches Discord's field limit
- add a regression test with an emoji exactly across the truncation boundary

## Verification
- `dotnet build` — passed with the existing SQLitePCLRaw vulnerability warning
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter 'FullyQualifiedName~QuoteServiceTests.FormatQuoteListFieldValue' --no-restore` — passed, 2/2
- `dotnet test --no-build` — 298 passed, 2 failed because this runner uses invariant globalization and cannot load `tr-TR`; the same two tests fail on upstream `develop`
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change only shortens truncated output by one UTF-16 code unit when the normal boundary would split a valid surrogate pair.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
