### PR TITLE
fix: prevent past XP rank overflow

### DIFF
--- a/Morpheus.Tests/ActivityLeaderboardServiceTests.cs
+++ b/Morpheus.Tests/ActivityLeaderboardServiceTests.cs
@@ -110,6 +110,65 @@ public class ActivityLeaderboardServiceTests
     }
 
     [Fact]
+    public async Task GetGlobalPastXpLeaderboardAsync_HandlesViewerTotalAboveIntMaxValue()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        User viewer = new() { DiscordId = 1, Username = "viewer" };
+        User runnerUp = new() { DiscordId = 2, Username = "runner-up" };
+        Guild guild = new() { DiscordId = 1, Name = "Test guild" };
+        db.AddRange(viewer, runnerUp, guild);
+        await db.SaveChangesAsync();
+
+        db.UserActivity.AddRange(
+            new UserActivity
+            {
+                UserId = viewer.Id,
+                GuildId = guild.Id,
+                DiscordMessageId = 1,
+                XpGained = int.MaxValue,
+                InsertDate = DateTime.UtcNow
+            },
+            new UserActivity
+            {
+                UserId = viewer.Id,
+                GuildId = guild.Id,
+                DiscordMessageId = 2,
+                XpGained = 1,
+                InsertDate = DateTime.UtcNow
+            },
+            new UserActivity
+            {
+                UserId = runnerUp.Id,
+                GuildId = guild.Id,
+                DiscordMessageId = 3,
+                XpGained = int.MaxValue,
+                InsertDate = DateTime.UtcNow
+            });
+        await db.SaveChangesAsync();
+
+        ActivityLeaderboardService service = new(db);
+
+        ActivityLeaderboardQueryResult result = await service.GetGlobalPastXpLeaderboardAsync(
+            viewerUserId: viewer.Id,
+            days: 1,
+            page: 1);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Page);
+        Assert.StartsWith("[1] | viewer:", result.Page.Lines[0]);
+        Assert.EndsWith($"with {(long)int.MaxValue + 1} XP", result.Page.Lines[0]);
+        Assert.Equal("Your rank: #1", result.Page.RankLine);
+    }
+
+    [Fact]
     public async Task GetGuildXpLeaderboardAsync_OrdersTiesByUserIdAcrossPages()
     {
         await using SqliteConnection connection = new("Data Source=:memory:");

--- a/Services/ActivityLeaderboardService.cs
+++ b/Services/ActivityLeaderboardService.cs
@@ -53,7 +53,7 @@ public class ActivityLeaderboardService(DB dbContext)
 
         var query = baseQuery
             .GroupBy(ua => ua.UserId)
-            .Select(g => new { UserId = g.Key, Value = (long)g.Sum(x => x.XpGained) })
+            .Select(g => new { UserId = g.Key, Value = g.Sum(x => (long)x.XpGained) })
             .OrderByDescending(x => x.Value)
             .ThenBy(x => x.UserId);
 
@@ -112,7 +112,7 @@ public class ActivityLeaderboardService(DB dbContext)
 
         var query = baseQuery
             .GroupBy(ua => ua.UserId)
-            .Select(g => new { UserId = g.Key, Value = (long)g.Sum(x => x.XpGained) })
+            .Select(g => new { UserId = g.Key, Value = g.Sum(x => (long)x.XpGained) })
             .OrderByDescending(x => x.Value)
             .ThenBy(x => x.UserId);
 
@@ -462,10 +462,12 @@ public class ActivityLeaderboardService(DB dbContext)
         if (!hasUser)
             return "Your rank: N/A";
 
-        int mySum = await baseQuery.Where(ua => ua.UserId == viewerUserId.Value).SumAsync(ua => ua.XpGained);
+        long mySum = await baseQuery
+            .Where(ua => ua.UserId == viewerUserId.Value)
+            .SumAsync(ua => (long)ua.XpGained);
         int better = await baseQuery
             .GroupBy(ua => ua.UserId)
-            .Select(g => new { Sum = g.Sum(ua => ua.XpGained) })
+            .Select(g => new { Sum = g.Sum(ua => (long)ua.XpGained) })
             .CountAsync(x => x.Sum > mySum);
 
         return $"Your rank: #{better + 1}";


### PR DESCRIPTION
## Summary
- widen past-XP leaderboard aggregation before summing so totals above `Int32.MaxValue` remain valid
- compute viewer rank comparisons with `long` totals
- add a SQLite regression test covering a viewer total of 2,147,483,648 XP

## Verification
- `dotnet build --no-restore` — passed (1 existing NU1903 package advisory warning)
- `dotnet test --filter 'FullyQualifiedName~ActivityLeaderboardServiceTests' --no-restore` — passed, 7/7
- `dotnet test --no-restore` — 298/300 passed; 2 unrelated `MiscModuleTests` cases failed because this runner only supports invariant globalization and cannot load `tr-TR`
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change only widens existing XP aggregates and adds regression coverage; no schema or command interface changes.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
