### PR TITLE
fix: parse namespaced RSS entries

### DIFF
--- a/Morpheus.Tests/RssFeedServiceTests.cs
+++ b/Morpheus.Tests/RssFeedServiceTests.cs
@@ -1,4 +1,5 @@
 using Morpheus.Services;
+using System.Xml.Linq;
 
 namespace Morpheus.Tests;
 
@@ -28,6 +29,32 @@ public class RssFeedServiceTests
     public void ParsePublished_WhenValueIsInvalid_ReturnsMinimumValue()
     {
         Assert.Equal(DateTime.MinValue, RssFeedService.ParsePublished("not-a-date"));
+    }
+
+    [Fact]
+    public void ParseEntries_ParsesNamespacedRssItems()
+    {
+        XDocument document = XDocument.Parse("""
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                     xmlns="http://purl.org/rss/1.0/"
+                     xmlns:dc="http://purl.org/dc/elements/1.1/">
+              <channel rdf:about="https://example.com/feed">
+                <title>Example feed</title>
+              </channel>
+              <item rdf:about="https://example.com/posts/1">
+                <title>Namespaced item</title>
+                <link>https://example.com/posts/1</link>
+                <dc:date>2025-07-30T12:00:00+02:00</dc:date>
+              </item>
+            </rdf:RDF>
+            """);
+
+        RssFeedService.FeedEntry entry = Assert.Single(RssFeedService.ParseRssEntries(document));
+
+        Assert.Equal("https://example.com/posts/1", entry.EntryId);
+        Assert.Equal("Namespaced item", entry.Title);
+        Assert.Equal("https://example.com/posts/1", entry.Link);
+        Assert.Equal(new DateTime(2025, 7, 30, 10, 0, 0, DateTimeKind.Utc), entry.Published);
     }
 
     [Fact]

--- a/Services/RssFeedService.cs
+++ b/Services/RssFeedService.cs
@@ -36,7 +36,7 @@ public class RssFeedService(LogsService logsService)
 
             List<FeedEntry> entries = [];
 
-            // Atom (<entry>) first, then RSS 2.0 (<item>).
+            // Atom (<entry>) first, then RSS (<item>), including namespaced RSS 1.0 feeds.
             List<XElement> atomEntries = doc.Descendants(Atom + "entry").ToList();
             if (atomEntries.Count > 0)
             {
@@ -56,19 +56,7 @@ public class RssFeedService(LogsService logsService)
             }
             else
             {
-                foreach (XElement it in doc.Descendants().Where(x => x.Name.LocalName == "item"))
-                {
-                    string link = it.Element("link")?.Value
-                                  ?? it.Elements("link").FirstOrDefault()?.Attribute("href")?.Value
-                                  ?? string.Empty;
-                    string id = it.Element("guid")?.Value ?? it.Element("id")?.Value ?? link;
-                    string title = it.Element("title")?.Value ?? string.Empty;
-                    string pubRaw = it.Element("pubDate")?.Value ?? it.Element("published")?.Value ?? string.Empty;
-                    DateTime published = ParsePublished(pubRaw);
-
-                    if (!string.IsNullOrWhiteSpace(id))
-                        entries.Add(new FeedEntry(id, title, link, published));
-                }
+                entries.AddRange(ParseRssEntries(doc));
             }
 
             XElement? channel = doc.Descendants().FirstOrDefault(x => x.Name.LocalName == "channel");
@@ -96,6 +84,36 @@ public class RssFeedService(LogsService logsService)
             return (null, null, []);
         }
     }
+
+    internal static IReadOnlyList<FeedEntry> ParseRssEntries(XDocument doc)
+    {
+        List<FeedEntry> entries = [];
+
+        foreach (XElement item in doc.Descendants().Where(x => x.Name.LocalName == "item"))
+        {
+            XElement? linkElement = ChildByLocalName(item, "link");
+            string link = linkElement?.Value
+                          ?? linkElement?.Attribute("href")?.Value
+                          ?? string.Empty;
+            string id = ChildByLocalName(item, "guid")?.Value
+                        ?? ChildByLocalName(item, "id")?.Value
+                        ?? link;
+            string title = ChildByLocalName(item, "title")?.Value ?? string.Empty;
+            string pubRaw = ChildByLocalName(item, "pubDate")?.Value
+                            ?? ChildByLocalName(item, "published")?.Value
+                            ?? ChildByLocalName(item, "date")?.Value
+                            ?? string.Empty;
+            DateTime published = ParsePublished(pubRaw);
+
+            if (!string.IsNullOrWhiteSpace(id))
+                entries.Add(new FeedEntry(id, title, link, published));
+        }
+
+        return entries;
+    }
+
+    private static XElement? ChildByLocalName(XElement parent, string localName) =>
+        parent.Elements().FirstOrDefault(element => element.Name.LocalName == localName);
 
     internal static DateTime ParsePublished(string value) =>
         DateTime.TryParse(


### PR DESCRIPTION
## Summary
- parse RSS item fields by local XML name so RSS 1.0 and other namespaced feeds produce entries
- recognize Dublin Core `dc:date` publication timestamps used by RSS 1.0
- add a regression test covering a namespaced RDF/RSS item

## Verification
- `dotnet build` — passed with the existing `SQLitePCLRaw.lib.e_sqlite3` NU1903 warning
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~RssFeedServiceTests --no-build` — passed, 7/7
- `dotnet test --no-build` — 298/300 passed; two existing `MiscModuleTests` cases failed because this runner supports only invariant globalization and cannot load `tr-TR`
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change preserves Atom parsing and unnamespaced RSS behavior while broadening RSS child-element matching; coverage includes the new namespace path.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
