### PR TITLE
fix: support uncached transfer recipients

### DIFF
--- a/Modules/StocksModule.cs
+++ b/Modules/StocksModule.cs
@@ -165,10 +165,7 @@ public class StocksModule(DB dbContext, StocksService stocksService, ChannelServ
 
         User? receiver = await dbContext.Users.FirstOrDefaultAsync(u => u.DiscordId == targetUser.Id);
         if (receiver == null)
-        {
-            if (targetUser is SocketUser socketTarget)
-                receiver = await usersService.TryGetCreateUser(socketTarget);
-        }
+            receiver = await usersService.TryGetCreateUser(targetUser);
 
         if (receiver == null) { await ReplyAsync("Recipient not found."); return; }
 
@@ -771,11 +768,7 @@ public class StocksModule(DB dbContext, StocksService stocksService, ChannelServ
 
         User? receiver = await dbContext.Users.FirstOrDefaultAsync(u => u.DiscordId == targetUser.Id);
         if (receiver == null)
-        {
-            // Auto-create the receiver if they exist on Discord
-            if (targetUser is SocketUser socketTarget)
-                receiver = await usersService.TryGetCreateUser(socketTarget);
-        }
+            receiver = await usersService.TryGetCreateUser(targetUser);
 
         if (receiver == null) { await ReplyAsync("Recipient not found."); return; }
 

--- a/Morpheus.Tests/UsersServiceTests.cs
+++ b/Morpheus.Tests/UsersServiceTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using Discord;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class UsersServiceTests
+{
+    [Fact]
+    public async Task TryGetCreateUser_CreatesUserFromNonSocketUser()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        UsersService service = new(db, new LogsService(new LogQueue()));
+        IUser discordUser = CreateUser(123, "rest-user");
+
+        User result = await service.TryGetCreateUser(discordUser);
+
+        Assert.Equal((ulong)123, result.DiscordId);
+        Assert.Equal("rest-user", result.Username);
+        Assert.Single(await db.Users.ToListAsync());
+    }
+
+    private static IUser CreateUser(ulong id, string username)
+    {
+        IUser user = DispatchProxy.Create<IUser, UserProxy>();
+        UserProxy proxy = (UserProxy)(object)user;
+        proxy.Id = id;
+        proxy.Username = username;
+        return user;
+    }
+
+    public class UserProxy : DispatchProxy
+    {
+        public ulong Id { get; set; }
+        public string Username { get; set; } = string.Empty;
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) => targetMethod?.Name switch
+        {
+            "get_Id" => Id,
+            "get_Username" => Username,
+            _ => throw new NotSupportedException(targetMethod?.Name)
+        };
+    }
+}

--- a/Services/UsersService.cs
+++ b/Services/UsersService.cs
@@ -1,4 +1,5 @@
-﻿using Discord.WebSocket;
+﻿using Discord;
+using Discord.WebSocket;
 using Microsoft.EntityFrameworkCore;
 using Morpheus.Database;
 using Morpheus.Database.Models;
@@ -6,7 +7,7 @@ using Morpheus.Database.Models;
 namespace Morpheus.Services;
 public class UsersService(DB dbContext, LogsService logsService)
 {
-    public async Task<User> TryGetCreateUser(SocketUser user)
+    public async Task<User> TryGetCreateUser(IUser user)
     {
         User? userDb = await dbContext.Users.FirstOrDefaultAsync(u => u.DiscordId == user.Id);
 


### PR DESCRIPTION
## Summary
- allow user creation from any Discord `IUser`, including uncached REST-backed users
- create missing recipients for both money and stock transfers instead of rejecting non-socket users
- add a regression test covering creation from a non-`SocketUser` implementation

## Verification
- `dotnet build` — passed: 0 errors (2 existing dependency vulnerability warnings)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~UsersServiceTests` — passed: 1/1
- `dotnet test` — 298 passed, 2 failed: existing `MiscModuleTests.NormalizeTimeUntilEventName_NormalizesCase` cases require `tr-TR`, unavailable in this runner's globalization-invariant environment
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low — the change broadens an existing user-creation API from `SocketUser` to its `IUser` interface and only affects missing transfer recipients.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
