### PR TITLE
fix: persist honeypot bans before notifications

### DIFF
--- a/Handlers/HoneypotHandler.cs
+++ b/Handlers/HoneypotHandler.cs
@@ -77,35 +77,66 @@ public class HoneypotHandler
         if (guildUser.GuildPermissions.Administrator)
             return;
 
+        DateTime bannedAt = DateTime.UtcNow;
+        var logsService = scope.ServiceProvider.GetRequiredService<LogsService>();
+
         // Ban the user and delete their messages from the past day
         try
         {
-            // Ban with pruneDays set to 1 (deletes messages from past 24 hours)
-            await guildChannel.Guild.AddBanAsync(
-                user: guildUser,
-                pruneDays: 1,
-                reason: $"Honeypot triggered (7 day ban) on {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}"
+            await ExecuteTemporaryBanWorkflowAsync(
+                banUser: () => guildChannel.Guild.AddBanAsync(
+                    user: guildUser,
+                    pruneDays: 1,
+                    reason: $"Honeypot triggered (7 day ban) on {bannedAt:yyyy-MM-dd HH:mm:ss}"
+                ),
+                persistTemporaryBan: () => RecordTemporaryBanAsync(
+                    db,
+                    guildChannel.Guild.Id,
+                    guildUser.Id,
+                    bannedAt
+                ),
+                sendNotification: () => welcomeChannel.SendMessageAsync(
+                    $"{guildUser.Mention} has been automatically banned after posting in the honeypot channel."
+                ),
+                logNotificationFailure: ex => logsService.Log(
+                    $"HoneypotHandler: banned user {message.Author.Mention}, but failed to send the welcome-channel notification: {ex.Message}"
+                )
             );
-
-            // Send notification to welcome channel
-            await welcomeChannel.SendMessageAsync(
-                $"{guildUser.Mention} has been automatically banned after posting in the honeypot channel."
-            );
-
-            // Record temporary ban for 7 days
-            db.TemporaryBans.Add(new TemporaryBan
-            {
-                GuildId = guildChannel.Guild.Id,
-                UserId = guildUser.Id,
-                Reason = $"Honeypot temporary ban. Banned on {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}",
-                ExpiresAt = DateTime.UtcNow.AddDays(7)
-            });
-            await db.SaveChangesAsync();
         }
         catch (Exception ex)
         {
-            var logsService = scope.ServiceProvider.GetRequiredService<LogsService>();
-            logsService.Log($"HoneypotHandler: failed to ban user {message.Author.Mention}: {ex.Message}");
+            logsService.Log($"HoneypotHandler: failed to ban or record user {message.Author.Mention}: {ex.Message}");
         }
+    }
+
+    internal static async Task ExecuteTemporaryBanWorkflowAsync(
+        Func<Task> banUser,
+        Func<Task> persistTemporaryBan,
+        Func<Task> sendNotification,
+        Action<Exception> logNotificationFailure)
+    {
+        await banUser();
+        await persistTemporaryBan();
+
+        try
+        {
+            await sendNotification();
+        }
+        catch (Exception ex)
+        {
+            logNotificationFailure(ex);
+        }
+    }
+
+    internal static async Task RecordTemporaryBanAsync(DB db, ulong guildId, ulong userId, DateTime bannedAt)
+    {
+        db.TemporaryBans.Add(new TemporaryBan
+        {
+            GuildId = guildId,
+            UserId = userId,
+            Reason = $"Honeypot temporary ban. Banned on {bannedAt:yyyy-MM-dd HH:mm:ss}",
+            ExpiresAt = bannedAt.AddDays(7)
+        });
+        await db.SaveChangesAsync();
     }
 }

--- a/Morpheus.Tests/HoneypotHandlerTests.cs
+++ b/Morpheus.Tests/HoneypotHandlerTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
+using Morpheus.Handlers;
+
+namespace Morpheus.Tests;
+
+public class HoneypotHandlerTests
+{
+    [Fact]
+    public async Task ExecuteTemporaryBanWorkflow_WhenNotificationFails_BanRemainsRecorded()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        List<string> calls = [];
+        InvalidOperationException notificationError = new("Channel unavailable");
+        Exception? loggedError = null;
+        DateTime bannedAt = new(2026, 8, 9, 12, 34, 56, DateTimeKind.Utc);
+
+        await HoneypotHandler.ExecuteTemporaryBanWorkflowAsync(
+            banUser: () =>
+            {
+                calls.Add("ban");
+                return Task.CompletedTask;
+            },
+            persistTemporaryBan: async () =>
+            {
+                calls.Add("persist");
+                await HoneypotHandler.RecordTemporaryBanAsync(db, guildId: 1, userId: 2, bannedAt);
+            },
+            sendNotification: () =>
+            {
+                calls.Add("notify");
+                return Task.FromException(notificationError);
+            },
+            logNotificationFailure: ex => loggedError = ex
+        );
+
+        db.ChangeTracker.Clear();
+        TemporaryBan persistedBan = await db.TemporaryBans.SingleAsync();
+
+        Assert.Equal(["ban", "persist", "notify"], calls);
+        Assert.Same(notificationError, loggedError);
+        Assert.Equal((ulong)1, persistedBan.GuildId);
+        Assert.Equal((ulong)2, persistedBan.UserId);
+        Assert.Equal(bannedAt.AddDays(7), persistedBan.ExpiresAt);
+        Assert.Null(persistedBan.UnbannedAt);
+    }
+
+    [Fact]
+    public async Task ExecuteTemporaryBanWorkflow_WhenPersistenceFails_DoesNotSendNotification()
+    {
+        List<string> calls = [];
+        InvalidOperationException persistenceError = new("Database unavailable");
+
+        InvalidOperationException thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            HoneypotHandler.ExecuteTemporaryBanWorkflowAsync(
+                banUser: () =>
+                {
+                    calls.Add("ban");
+                    return Task.CompletedTask;
+                },
+                persistTemporaryBan: () =>
+                {
+                    calls.Add("persist");
+                    return Task.FromException(persistenceError);
+                },
+                sendNotification: () =>
+                {
+                    calls.Add("notify");
+                    return Task.CompletedTask;
+                },
+                logNotificationFailure: _ => { }
+            )
+        );
+
+        Assert.Same(persistenceError, thrown);
+        Assert.Equal(["ban", "persist"], calls);
+    }
+}


### PR DESCRIPTION
## Summary
- persist seven-day honeypot ban records before attempting the welcome-channel notification
- treat notification delivery as best-effort so a Discord send failure cannot suppress the unban schedule
- add regression coverage for notification and persistence failures

## Verification
- `dotnet build --no-restore` — passed (one existing SQLitePCLRaw vulnerability warning)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~HoneypotHandlerTests --no-restore` — passed, 2/2
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-build --no-restore` — 299 passed, 2 failed because this runner cannot load `tr-TR` in globalization-invariant mode (the existing `MiscModuleTests` failures)
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change preserves the ban and seven-day expiry while only reordering persistence ahead of a best-effort notification.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
