### PR TITLE
fix: prevent timezone shifts in activity graph dates

### DIFF
--- a/Services/ActivityGraphService.cs
+++ b/Services/ActivityGraphService.cs
@@ -136,29 +136,25 @@ public class ActivityGraphService(DB dbContext)
     {
         string[] parts = input.Split([".."], StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length != 2 ||
-            !DateTime.TryParseExact(parts[0], "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime start) ||
-            !DateTime.TryParseExact(parts[1], "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime end))
+            !DateOnly.TryParseExact(parts[0], "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateOnly start) ||
+            !DateOnly.TryParseExact(parts[1], "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateOnly end))
         {
             return ActivityGraphParseResult.Error(
                 $"Invalid date range format. Use YYYY-MM-DD..YYYY-MM-DD and ensure the range is at most {maxDays} days and start <= end.");
         }
 
-        start = start.Date;
-        end = end.Date;
         if (end < start)
             (start, end) = (end, start);
 
-        double span = (end - start).TotalDays + 1;
+        int span = end.DayNumber - start.DayNumber + 1;
         if (span < 7)
-        {
-            end = start.AddDays(6);
             span = 7;
-        }
 
         if (!isOwner && span > maxDays)
             return ActivityGraphParseResult.Error($"Date range exceeds maximum of {maxDays} days.");
 
-        return ActivityGraphParseResult.Valid((int)span, NormalizeToUtc(start));
+        DateTime explicitStart = start.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        return ActivityGraphParseResult.Valid(span, explicitStart);
     }
 
     private static int NormalizeDayCount(int days, bool isOwner, int maxDays)


### PR DESCRIPTION
## Summary
- parse activity graph date ranges as calendar-only values so the host timezone cannot shift the requested UTC start date
- preserve inclusive span, reversed-range, minimum-seven-day, and maximum-range behavior

## Verification
- `dotnet build` — passed with 0 errors (119 existing dependency/SDK warnings)
- `TZ=America/Los_Angeles dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter FullyQualifiedName~ActivityGraphServiceTests --logger "console;verbosity=minimal"` — passed 10/10; before the fix, the existing date-range test failed with May 1 shifted to April 30
- `TZ=Pacific/Kiritimati dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter FullyQualifiedName~ActivityGraphServiceTests --logger "console;verbosity=minimal"` — passed 10/10
- `dotnet test --no-build --logger "console;verbosity=minimal"` — 297 passed, 2 failed because this runner uses globalization-invariant mode and cannot load `tr-TR`; the same two failures were reproduced on unmodified `upstream/develop`
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change is limited to date-only range parsing and retains the existing validation and range rules.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
