### PR TITLE
fix: use safe emoji archive paths

### DIFF
--- a/Modules/EmojisModule.cs
+++ b/Modules/EmojisModule.cs
@@ -155,7 +155,7 @@ public class EmojisModule : ModuleBase<SocketCommandContextExtended>
     {
         SocketGuild guild = Context.Guild;
         string directory = Path.Combine(Path.GetTempPath(), "emojis", guild.Id.ToString());
-        string zipPath = Path.Combine(Path.GetTempPath(), $"{guild.Name}_Emojis.zip");
+        string zipPath = GetEmojiArchivePath(Path.GetTempPath(), guild.Id);
 
         // Ensure directory is clean
         if (Directory.Exists(directory))
@@ -196,6 +196,9 @@ public class EmojisModule : ModuleBase<SocketCommandContextExtended>
 
         await progressMessage.ModifyAsync(m => m.Content = "Emoji download process completed!");
     }
+
+    internal static string GetEmojiArchivePath(string tempPath, ulong guildId) =>
+        Path.Combine(tempPath, $"Morpheus_Emojis_{guildId}.zip");
 
     // ─── Import Emoji Command ────────────────────────────────────────────
 

--- a/Morpheus.Tests/EmojisModuleTests.cs
+++ b/Morpheus.Tests/EmojisModuleTests.cs
@@ -21,4 +21,14 @@ public class EmojisModuleTests
         Assert.True(found);
         Assert.Equal(42UL, messageId);
     }
+
+    [Fact]
+    public void GetEmojiArchivePath_UsesGuildIdUnderTempDirectory()
+    {
+        string tempPath = Path.Combine("tmp", "morpheus-tests");
+
+        string archivePath = EmojisModule.GetEmojiArchivePath(tempPath, 123UL);
+
+        Assert.Equal(Path.Combine(tempPath, "Morpheus_Emojis_123.zip"), archivePath);
+    }
 }


### PR DESCRIPTION
## Summary
- build emoji archive paths from the numeric guild ID instead of the user-controlled guild name
- keep archives directly under the temporary directory and avoid collisions between guilds with the same name
- add regression coverage for the generated archive path

## Verification
- `dotnet build` — passed with 0 errors (2 existing NU1903 warnings)
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~EmojisModuleTests --logger 'console;verbosity=minimal'` — passed: 3/3
- `dotnet test --no-build --logger 'console;verbosity=minimal'` — 298 passed, 2 failed; both failures are the existing invariant-globalization `tr-TR` cases in `MiscModuleTests`, reproduced on `upstream/develop` (297 passed, the same 2 failed)
- `git diff --check` — passed

## Risk
- Low: only the temporary ZIP filename changes; archive contents and command behavior are otherwise unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
