### PR TITLE
fix: pin cron jobs to UTC

### DIFF
--- a/Extensions/BotStartupExtensions.cs
+++ b/Extensions/BotStartupExtensions.cs
@@ -95,7 +95,7 @@ public static class BotStartupExtensions
             q.ScheduleJob<BotAvatarJob>(trigger => trigger
                 .WithIdentity("botAvatarDaily", "discord")
                 .StartNow()
-                .WithCronSchedule("0 0 0 * * ?")
+                .WithCronSchedule("0 0 0 * * ?", schedule => schedule.InTimeZone(TimeZoneInfo.Utc))
             );
 
             q.ScheduleJob<TemporaryBansJob>(trigger => trigger
@@ -107,19 +107,19 @@ public static class BotStartupExtensions
             q.ScheduleJob<HoneypotRenameJob>(trigger => trigger
                 .WithIdentity("honeypotRenameDaily", "discord")
                 .StartNow()
-                .WithCronSchedule("0 5 0 * * ?")
+                .WithCronSchedule("0 5 0 * * ?", schedule => schedule.InTimeZone(TimeZoneInfo.Utc))
             );
 
             q.ScheduleJob<UbiJob>(trigger => trigger
                 .WithIdentity("ubiDistribution", "discord")
                 .StartNow()
-                .WithCronSchedule("0 0 0 * * ?")
+                .WithCronSchedule("0 0 0 * * ?", schedule => schedule.InTimeZone(TimeZoneInfo.Utc))
             );
 
             q.ScheduleJob<WealthTaxJob>(trigger => trigger
                 .WithIdentity("wealthTax", "discord")
                 .StartNow()
-                .WithCronSchedule("0 30 23 * * ?")
+                .WithCronSchedule("0 30 23 * * ?", schedule => schedule.InTimeZone(TimeZoneInfo.Utc))
             );
 
             q.ScheduleJob<StockUpdateJob>(trigger => trigger

--- a/Morpheus.Tests/BotStartupExtensionsTests.cs
+++ b/Morpheus.Tests/BotStartupExtensionsTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.DependencyInjection;
+using Morpheus.Extensions;
+using Quartz;
+
+namespace Morpheus.Tests;
+
+public class BotStartupExtensionsTests
+{
+    [Fact]
+    public async Task AddBotJobs_ConfiguresCronTriggersInUtc()
+    {
+        await using ServiceProvider services = new ServiceCollection()
+            .AddLogging()
+            .AddBotJobs()
+            .BuildServiceProvider();
+
+        IScheduler scheduler = await services.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        try
+        {
+            string[] triggerNames = ["botAvatarDaily", "honeypotRenameDaily", "ubiDistribution", "wealthTax"];
+
+            foreach (string triggerName in triggerNames)
+            {
+                ITrigger? trigger = await scheduler.GetTrigger(new TriggerKey(triggerName, "discord"));
+                ICronTrigger cronTrigger = Assert.IsAssignableFrom<ICronTrigger>(trigger);
+
+                Assert.Equal(TimeZoneInfo.Utc, cronTrigger.TimeZone);
+            }
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Pin every Quartz cron schedule to UTC so host timezone changes cannot shift daily bot avatar, honeypot rename, UBI, or wealth-tax execution times.
- Add a regression test that resolves each configured cron trigger and verifies its timezone.

## Verification
- `dotnet build` — passed: 0 errors; 2 existing NU1903 dependency warnings.
- `dotnet test --no-build --filter 'FullyQualifiedName~BotStartupExtensionsTests' --logger 'console;verbosity=minimal'` — passed: 1/1.
- `dotnet test --no-build --logger 'console;verbosity=minimal'` — 298 passed, 2 failed: the same pre-existing `tr-TR` culture cases fail on synced `develop` because this runner uses globalization-invariant mode.
- `git diff --check upstream/develop...HEAD` — passed.

## Risk
- Low — this makes existing cron expressions deterministic across deployment hosts without changing their documented clock times.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
