### PR TITLE
fix: stabilize slots button bet values

### DIFF
--- a/Modules/SlotsModule.cs
+++ b/Modules/SlotsModule.cs
@@ -11,6 +11,7 @@ using Morpheus.Handlers;
 using Morpheus.Services;
 using Morpheus.Utilities;
 using System.Data;
+using System.Globalization;
 using System.Text;
 
 namespace Morpheus.Modules;
@@ -22,6 +23,15 @@ public class SlotsModule : ModuleBase<SocketCommandContextExtended>
     private readonly DB dbContext;
     private readonly EconomyService economyService;
     private readonly SlotsService slotsService;
+
+    internal static string FormatButtonBet(decimal bet) =>
+        bet.ToString("F2", CultureInfo.InvariantCulture);
+
+    internal static bool TryParseButtonBet(string value, out decimal bet)
+    {
+        const NumberStyles styles = NumberStyles.AllowDecimalPoint;
+        return decimal.TryParse(value, styles, CultureInfo.InvariantCulture, out bet);
+    }
 
     public SlotsModule(
         DB dbContext,
@@ -193,9 +203,9 @@ public class SlotsModule : ModuleBase<SocketCommandContextExtended>
         bool canHalf = halfBet >= SlotsService.MinBet;
 
         ComponentBuilder components = new ComponentBuilder()
-            .WithButton($"Spin Again (${bet:F2})", customId: $"slots_again:{userId}:{bet:F2}", style: ButtonStyle.Primary, emote: new Emoji("🔁"))
-            .WithButton($"Double (${(canDouble ? doubleBet : bet):F2})", customId: $"slots_double:{userId}:{doubleBet:F2}", style: ButtonStyle.Danger, emote: new Emoji("⏫"), disabled: !canDouble)
-            .WithButton($"Half (${(canHalf ? halfBet : bet):F2})", customId: $"slots_half:{userId}:{halfBet:F2}", style: ButtonStyle.Secondary, emote: new Emoji("⏬"), disabled: !canHalf);
+            .WithButton($"Spin Again (${bet:F2})", customId: $"slots_again:{userId}:{FormatButtonBet(bet)}", style: ButtonStyle.Primary, emote: new Emoji("🔁"))
+            .WithButton($"Double (${(canDouble ? doubleBet : bet):F2})", customId: $"slots_double:{userId}:{FormatButtonBet(doubleBet)}", style: ButtonStyle.Danger, emote: new Emoji("⏫"), disabled: !canDouble)
+            .WithButton($"Half (${(canHalf ? halfBet : bet):F2})", customId: $"slots_half:{userId}:{FormatButtonBet(halfBet)}", style: ButtonStyle.Secondary, emote: new Emoji("⏬"), disabled: !canHalf);
 
         return (embed.Build(), bet, components);
     }
@@ -252,7 +262,7 @@ public class SlotsModule : ModuleBase<SocketCommandContextExtended>
         string[] parts = custom.Split(':', 3);
         if (parts.Length < 3) return;
         if (!int.TryParse(parts[1], out int userId)) return;
-        if (!decimal.TryParse(parts[2], out decimal bet)) return;
+        if (!TryParseButtonBet(parts[2], out decimal bet)) return;
 
         // Only the original user can use the buttons
         User? user = await dbContext.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId);

--- a/Morpheus.Tests/SlotsModuleTests.cs
+++ b/Morpheus.Tests/SlotsModuleTests.cs
@@ -1,0 +1,59 @@
+using System.Globalization;
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class SlotsModuleTests
+{
+    [Fact]
+    public void FormatButtonBet_UsesInvariantDecimalSeparator()
+    {
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo commaDecimalCulture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        commaDecimalCulture.NumberFormat.NumberDecimalSeparator = ",";
+        commaDecimalCulture.NumberFormat.NumberGroupSeparator = ".";
+
+        try
+        {
+            CultureInfo.CurrentCulture = commaDecimalCulture;
+
+            Assert.Equal("12.50", SlotsModule.FormatButtonBet(12.50m));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public void TryParseButtonBet_UsesInvariantDecimalSeparator()
+    {
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo commaDecimalCulture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        commaDecimalCulture.NumberFormat.NumberDecimalSeparator = ",";
+        commaDecimalCulture.NumberFormat.NumberGroupSeparator = ".";
+
+        try
+        {
+            CultureInfo.CurrentCulture = commaDecimalCulture;
+
+            bool parsed = SlotsModule.TryParseButtonBet("12.50", out decimal bet);
+
+            Assert.True(parsed);
+            Assert.Equal(12.50m, bet);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Theory]
+    [InlineData("12,50")]
+    [InlineData("1,000")]
+    [InlineData("not-a-number")]
+    public void TryParseButtonBet_RejectsAmbiguousValues(string value)
+    {
+        Assert.False(SlotsModule.TryParseButtonBet(value, out _));
+    }
+}


### PR DESCRIPTION
## Summary
- serialize slots button bet values with the invariant decimal separator
- parse button bet values strictly with invariant culture so locale changes cannot reinterpret an amount
- add regression coverage for comma-decimal cultures and ambiguous comma-formatted values

## Verification
- `dotnet build` — passed: 0 errors (2 existing package-vulnerability warnings)
- `dotnet test --no-build --filter 'FullyQualifiedName~SlotsModuleTests|FullyQualifiedName~SlotsServiceTests' --logger 'console;verbosity=minimal'` — passed: 23/23
- `dotnet test --no-build --logger 'console;verbosity=minimal'` — partial: 302 passed, 2 unrelated existing `tr-TR` cases failed because this runner uses invariant globalization
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low — the change only makes the internal Discord component payload culture-independent; displayed currency formatting is unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
