### PR TITLE
fix: complete already removed temporary bans

### DIFF
--- a/Jobs/TemporaryBansJob.cs
+++ b/Jobs/TemporaryBansJob.cs
@@ -1,4 +1,6 @@
+using System.Net;
 using Discord;
+using Discord.Net;
 using Discord.WebSocket;
 using Microsoft.EntityFrameworkCore;
 using Morpheus.Database;
@@ -36,9 +38,12 @@ public class TemporaryBansJob(LogsService logsService, DB db, DiscordSocketClien
                     continue;
                 }
 
-                await guild.RemoveBanAsync(ban.UserId);
-                ban.UnbannedAt = DateTime.UtcNow;
-                Log($"Unbanned user {ban.UserId} from guild {ban.GuildId} (temp ban {ban.Id}).");
+                bool wasAlreadyUnbanned = await CompleteUnbanAsync(
+                    ban,
+                    () => guild.RemoveBanAsync(ban.UserId));
+                Log(wasAlreadyUnbanned
+                    ? $"User {ban.UserId} was already unbanned from guild {ban.GuildId} (temp ban {ban.Id})."
+                    : $"Unbanned user {ban.UserId} from guild {ban.GuildId} (temp ban {ban.Id}).");
             }
             catch (Exception ex)
             {
@@ -48,6 +53,28 @@ public class TemporaryBansJob(LogsService logsService, DB db, DiscordSocketClien
         }
 
         await db.SaveChangesAsync();
+    }
+
+    internal static async Task<bool> CompleteUnbanAsync(
+        TemporaryBan ban,
+        Func<Task> removeBanAsync)
+    {
+        bool wasAlreadyUnbanned = false;
+        try
+        {
+            await removeBanAsync();
+        }
+        catch (HttpException ex) when (
+            ex.HttpCode == HttpStatusCode.NotFound &&
+            ex.DiscordCode == DiscordErrorCode.UnknownBan)
+        {
+            // A moderator may have removed the ban before this job ran. Discord's
+            // Unknown Ban response means the desired state is already reached.
+            wasAlreadyUnbanned = true;
+        }
+
+        ban.UnbannedAt = DateTime.UtcNow;
+        return wasAlreadyUnbanned;
     }
 }
 

--- a/Morpheus.Tests/TemporaryBansJobTests.cs
+++ b/Morpheus.Tests/TemporaryBansJobTests.cs
@@ -1,3 +1,6 @@
+using System.Net;
+using Discord;
+using Discord.Net;
 using Discord.WebSocket;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -10,6 +13,45 @@ namespace Morpheus.Tests;
 
 public class TemporaryBansJobTests
 {
+    [Fact]
+    public async Task CompleteUnbanAsync_WhenBanIsAlreadyMissing_MarksBanCompleted()
+    {
+        TemporaryBan ban = new();
+        HttpException notFound = new(
+            HttpStatusCode.NotFound,
+            null!,
+            DiscordErrorCode.UnknownBan,
+            "Unknown Ban",
+            []);
+
+        bool wasAlreadyUnbanned = await TemporaryBansJob.CompleteUnbanAsync(
+            ban,
+            () => Task.FromException(notFound));
+
+        Assert.True(wasAlreadyUnbanned);
+        Assert.NotNull(ban.UnbannedAt);
+    }
+
+    [Fact]
+    public async Task CompleteUnbanAsync_WhenDifferentDiscordResourceIsMissing_LeavesBanPending()
+    {
+        TemporaryBan ban = new();
+        HttpException unknownGuild = new(
+            HttpStatusCode.NotFound,
+            null!,
+            DiscordErrorCode.UnknownGuild,
+            "Unknown Guild",
+            []);
+
+        HttpException thrown = await Assert.ThrowsAsync<HttpException>(() =>
+            TemporaryBansJob.CompleteUnbanAsync(
+                ban,
+                () => Task.FromException(unknownGuild)));
+
+        Assert.Same(unknownGuild, thrown);
+        Assert.Null(ban.UnbannedAt);
+    }
+
     [Fact]
     public async Task Execute_WhenGuildIsUnavailable_LeavesBanPendingForRetry()
     {


### PR DESCRIPTION
## Summary
- stop retrying expired temporary bans when Discord confirms the ban was already removed
- distinguish the `Unknown Ban` 404 from other missing-resource errors so unrelated failures remain pending for retry
- add regression coverage for both outcomes

## Verification
- `dotnet build` — passed (0 errors; existing SQLitePCLRaw NU1903 warning)
- `dotnet test --no-build --filter 'FullyQualifiedName~TemporaryBansJobTests' --logger 'console;verbosity=minimal'` — passed (3/3)
- `dotnet test --no-build --logger 'console;verbosity=minimal'` — 299 passed, 2 failed because this runner cannot load `tr-TR` in globalization-invariant mode; the failures are in unchanged `MiscModuleTests` and are tracked by PR #81
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: only Discord `Unknown Ban` 404 responses are treated as completed; all other errors keep the existing retry behavior.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
