### PR TITLE
fix: attribute pins to original message author

### DIFF
--- a/Modules/UtilityModule.cs
+++ b/Modules/UtilityModule.cs
@@ -65,7 +65,7 @@ public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtend
         // Make an embed of the message details
         EmbedBuilder embed = new()
         {
-            Title = $"Pin in `#{message.Channel.Name}` by {Context.Message.Author.Username}",
+            Title = FormatPinTitle(message.Channel.Name, message.Author.Username),
             Url = message.GetJumpUrl(),
             Author = new EmbedAuthorBuilder()
             {
@@ -95,6 +95,9 @@ public class UtilityModule(DB dbContext) : ModuleBase<SocketCommandContextExtend
         messageId = referencedMessageId.GetValueOrDefault();
         return referencedMessageId.HasValue;
     }
+
+    internal static string FormatPinTitle(string channelName, string authorUsername) =>
+        $"Pin in `#{channelName}` by {authorUsername}";
 
     [Name("Reminder")]
     [Summary("Sets a reminder using a duration specification (e.g. '5 days and 3 hours'). Minimum 1 minute, maximum 100 years. Usage: reminder <duration> [@user] [text...]. Example: reminder 5 days and 3 hours @User Take a break. Reminders are executed once a minute.")]

--- a/Morpheus.Tests/UtilityModuleTests.cs
+++ b/Morpheus.Tests/UtilityModuleTests.cs
@@ -22,6 +22,14 @@ public class UtilityModuleTests
         Assert.Equal(42UL, messageId);
     }
 
+    [Fact]
+    public void FormatPinTitle_UsesReferencedMessageAuthor()
+    {
+        string title = UtilityModule.FormatPinTitle("general", "OriginalAuthor");
+
+        Assert.Equal("Pin in `#general` by OriginalAuthor", title);
+    }
+
     [Theory]
     [InlineData("5 days and 3 hours @User Take a break", "@User Take a break")]
     [InlineData("5 days, 3 hours: Take a break", "Take a break")]


### PR DESCRIPTION
## Summary
- attribute pin embed titles to the author of the referenced message instead of the moderator invoking `pin`
- add regression coverage for pin title formatting

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~UtilityModuleTests --logger console;verbosity=minimal` — passed: 11/11
- `dotnet build` — passed: 0 errors (2 existing package-vulnerability warnings)
- `dotnet test` — 298/300 passed; the two failures are existing `tr-TR` cases unavailable in this runner's globalization-invariant mode
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low — the change only corrects display attribution in pin embeds and does not alter permissions, persistence, or command flow.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
