### PR TITLE
fix: normalize YouTube feed timestamps

### DIFF
--- a/Morpheus.Tests/YoutubeFeedServiceTests.cs
+++ b/Morpheus.Tests/YoutubeFeedServiceTests.cs
@@ -4,6 +4,23 @@ namespace Morpheus.Tests;
 
 public class YoutubeFeedServiceTests
 {
+    [Theory]
+    [InlineData("2025-07-30T12:00:00+02:00", 10)]
+    [InlineData("2025-07-30T10:00:00Z", 10)]
+    public void ParsePublished_NormalizesAtomTimestampsToUtc(string value, int expectedHour)
+    {
+        DateTime published = YoutubeFeedService.ParsePublished(value);
+
+        Assert.Equal(new DateTime(2025, 7, 30, expectedHour, 0, 0, DateTimeKind.Utc), published);
+        Assert.Equal(DateTimeKind.Utc, published.Kind);
+    }
+
+    [Fact]
+    public void ParsePublished_WhenValueIsInvalid_ReturnsMinimumValue()
+    {
+        Assert.Equal(DateTime.MinValue, YoutubeFeedService.ParsePublished("not-a-date"));
+    }
+
     [Fact]
     public async Task FetchFeedAsync_WhenCallerCancels_PropagatesCancellation()
     {

--- a/Services/YoutubeFeedService.cs
+++ b/Services/YoutubeFeedService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Xml.Linq;
 using Discord;
 
@@ -36,7 +37,7 @@ public class YoutubeFeedService(LogsService logsService)
                 string link = e.Elements(Atom + "link").FirstOrDefault()?.Attribute("href")?.Value
                               ?? $"https://www.youtube.com/watch?v={vid}";
                 string pubRaw = e.Element(Atom + "published")?.Value ?? string.Empty;
-                DateTime.TryParse(pubRaw, out DateTime published);
+                DateTime published = ParsePublished(pubRaw);
 
                 entries.Add(new VideoEntry(vid, title, link, published));
             }
@@ -53,4 +54,13 @@ public class YoutubeFeedService(LogsService logsService)
             return (null, []);
         }
     }
+
+    internal static DateTime ParsePublished(string value) =>
+        DateTime.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out DateTime published)
+            ? published
+            : DateTime.MinValue;
 }


### PR DESCRIPTION
## Summary
- parse YouTube Atom publication timestamps with invariant culture
- normalize parsed offsets to UTC before feed entries are ordered
- cover offset, UTC, and invalid timestamp cases

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~YoutubeFeedServiceTests --logger "console;verbosity=minimal"` — passed: 4/4
- `dotnet build --no-restore` — passed: 0 errors, 1 existing package-vulnerability warning
- `dotnet test --no-build --logger "console;verbosity=minimal"` — 300 passed, 2 failed: existing `tr-TR` culture cases under globalization-invariant mode; the same failures reproduce on `upstream/develop`
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: the change is isolated to YouTube feed timestamp parsing and preserves `DateTime.MinValue` for invalid input.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
