### PR TITLE
docs: document Docker publish setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,18 @@ Install dotnet-ef (if needed):
 dotnet tool install --global dotnet-ef
 ```
 
+## Publishing the Docker image
+
+The publishing script reads registry credentials and image settings from `publish/.env`, which is intentionally ignored by Git. Create it from the checked-in template before publishing:
+
+```powershell
+Copy-Item .\publish\default.env .\publish\.env
+# Replace the placeholder values in publish\.env, then run:
+pwsh .\publish\publish.ps1
+```
+
+Keep `publish/.env` untracked because it contains registry credentials. Publishing also requires PowerShell and a running Docker daemon.
+
 ## Running the command list generator
 
 This repository includes a small Python script that extracts command metadata from the C# modules and writes `COMMANDS.md`.


### PR DESCRIPTION
## Summary
- document how to create the ignored `publish/.env` file from the checked-in template
- clarify the Docker publishing prerequisites, credential handling, and script invocation

## Verification
- `dotnet build` — passed with 0 errors and 2 NU1903 dependency warnings
- `dotnet test --no-build --logger 'console;verbosity=minimal'` — failed: 297 passed and 2 `MiscModuleTests` cases could not load `tr-TR` in this runner's globalization-invariant mode
- `git diff --check upstream/develop...HEAD` — passed
- publishing script execution — skipped because it requires registry credentials, a running Docker daemon, and pushes an image

## Risk
- low: documentation-only change matching the existing script and ignored environment-file paths

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
