### PR TITLE
fix: preserve collapsed SimHash whitespace

### DIFF
--- a/Morpheus.Tests/SimHasherTests.cs
+++ b/Morpheus.Tests/SimHasherTests.cs
@@ -4,6 +4,14 @@ namespace Morpheus.Tests;
 
 public class SimHasherTests
 {
+    [Theory]
+    [InlineData("a ! b", "a b")]
+    [InlineData("a \u0301 b", "a b")]
+    public void Normalize_CollapsesWhitespaceAcrossRemovedCharacters(string input, string expected)
+    {
+        Assert.Equal(expected, SimHasher.Normalize(input));
+    }
+
     [Fact]
     public void ComputeSimHash_ReturnsZeroHashForVeryShortNormalizedText()
     {

--- a/Utilities/Text/SimHasher.cs
+++ b/Utilities/Text/SimHasher.cs
@@ -27,7 +27,6 @@ public static class SimHasher
                 }
                 continue;
             }
-            lastWasSpace = false;
 
             // Strip combining marks (diacritics)
             var cat = CharUnicodeInfo.GetUnicodeCategory(ch.ToString(), 0);
@@ -42,6 +41,7 @@ public static class SimHasher
             if (Rune.IsDigit(ch))
             {
                 sb.Append('0');
+                lastWasSpace = false;
                 continue;
             }
 
@@ -50,6 +50,7 @@ public static class SimHasher
                 continue;
 
             sb.Append(ch.ToString());
+            lastWasSpace = false;
         }
 
         var result = sb.ToString().Trim();


### PR DESCRIPTION
## Summary
- keep SimHash whitespace collapsed when punctuation, symbols, or combining marks are removed between spaces
- add regression coverage for punctuation and combining-mark cases

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~SimHasherTests --logger 'console;verbosity=minimal'` — passed: 5/5
- `dotnet build` — passed: 0 errors (2 existing dependency vulnerability warnings)
- `dotnet test --no-build --logger 'console;verbosity=minimal'` — 299 passed, 2 failed: existing `tr-TR` cases require culture data unavailable in globalization-invariant mode
- `git diff --check` — passed

## Risk
- Low — the change only updates normalization state after characters that are actually retained and is covered by focused tests.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
