### PR TITLE
fix: clamp percentage bar input

### DIFF
--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Morpheus.Database;
 using Morpheus.Modules;
+using Morpheus.Utilities.Extensions;
 
 namespace Morpheus.Tests;
 
@@ -152,5 +153,13 @@ public class MiscModuleTests
     public void TryParseDiceInput_RejectsMalformedOrOutOfRangeInput(string input)
     {
         Assert.False(MiscModule.TryParseDiceInput(input, out _, out _));
+    }
+
+    [Theory]
+    [InlineData(-1, "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░")]
+    [InlineData(101, "██████████████████████████████")]
+    public void GetPercentageBar_ClampsOutOfRangeValues(int value, string expected)
+    {
+        Assert.Equal(expected, value.GetPercentageBar());
     }
 }

--- a/Utilities/Extensions/Extensions.cs
+++ b/Utilities/Extensions/Extensions.cs
@@ -73,6 +73,9 @@ public static partial class Extensions
         // Define the total length of the bar
         int totalLength = 30;
 
+        // Keep malformed or future caller input from producing an invalid bar length.
+        value = Math.Clamp(value, 0, 100);
+
         // Calculate the number of filled cells
         int filledCells = (int)Math.Round((double)value / 100 * totalLength);
 


### PR DESCRIPTION
## Summary
- Clamp percentage-bar inputs to the supported 0–100 range before calculating filled and empty cells.
- Add regression coverage for negative and over-100 inputs, which previously could make `StringBuilder.Append` throw.

## Verification
- `dotnet build --no-restore` — passed (1 pre-existing package vulnerability warning).
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter 'FullyQualifiedName~GetPercentageBar_ClampsOutOfRangeValues' --verbosity minimal` — passed (2 tests).
- `dotnet test --no-restore --verbosity minimal` — 299 passed, 2 failed because the environment runs in .NET globalization-invariant mode and cannot load the existing `tr-TR` culture regression tests.
- `git diff --check` — passed.

## Risk
- Low: normal 0–100 output is unchanged; only out-of-range inputs are clamped.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
