### PR TITLE
fix: ignore invalid Minecraft favicons

### DIFF
--- a/Modules/MiscModule.cs
+++ b/Modules/MiscModule.cs
@@ -649,10 +649,9 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
             .WithCurrentTimestamp();
 
         // Include image if the favicon exists
-        if (!string.IsNullOrEmpty(serverImageBase64))
+        if (TryDecodeMinecraftFavicon(serverImageBase64, out byte[] imageBytes))
         {
             embed.WithThumbnailUrl($"attachment://favicon.png"); // Point to an inline attachment URL
-            byte[] imageBytes = Convert.FromBase64String(serverImageBase64.Split(',')[1]); // Remove the data:image/png;base64, part
             MemoryStream stream = new(imageBytes);
             FileAttachment attachment = new(stream, "favicon.png");
 
@@ -674,6 +673,32 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
                 msg.Content = string.Empty;
                 msg.Embed = finalEmbed;
             });
+        }
+    }
+
+    internal static bool TryDecodeMinecraftFavicon(string? favicon, out byte[] imageBytes)
+    {
+        imageBytes = [];
+        if (string.IsNullOrWhiteSpace(favicon))
+            return false;
+
+        const string base64Marker = ";base64,";
+        int markerIndex = favicon.IndexOf(base64Marker, StringComparison.OrdinalIgnoreCase);
+        if (favicon.StartsWith("data:", StringComparison.OrdinalIgnoreCase) && markerIndex < 0)
+            return false;
+
+        string encodedImage = markerIndex >= 0
+            ? favicon[(markerIndex + base64Marker.Length)..]
+            : favicon;
+
+        try
+        {
+            imageBytes = Convert.FromBase64String(encodedImage);
+            return imageBytes.Length > 0;
+        }
+        catch (FormatException)
+        {
+            return false;
         }
     }
 

--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -109,6 +109,31 @@ public class MiscModuleTests
         Assert.Equal("https://api.urbandictionary.com/v0/define?term=C%23%20%26%20tea", result);
     }
 
+    [Theory]
+    [InlineData("data:image/png;base64,AQID")]
+    [InlineData("AQID")]
+    public void TryDecodeMinecraftFavicon_DecodesSupportedBase64Formats(string favicon)
+    {
+        bool decoded = MiscModule.TryDecodeMinecraftFavicon(favicon, out byte[] imageBytes);
+
+        Assert.True(decoded);
+        Assert.Equal([1, 2, 3], imageBytes);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("data:image/png,not-base64")]
+    [InlineData("data:image/png;base64,")]
+    [InlineData("not-base64")]
+    public void TryDecodeMinecraftFavicon_RejectsMissingOrMalformedImages(string? favicon)
+    {
+        bool decoded = MiscModule.TryDecodeMinecraftFavicon(favicon, out byte[] imageBytes);
+
+        Assert.False(decoded);
+        Assert.Empty(imageBytes);
+    }
+
     [Fact]
     public async Task LoveCompatibilityCommand_AllowsComparingWithInvoker()
     {


### PR DESCRIPTION
## Summary
- Decode Minecraft server favicons without assuming every API value contains a data-URI comma.
- Skip missing, empty, or malformed favicons so `pingmc` can still return the server-status embed.
- Cover valid data URIs, raw Base64, and malformed values with regression tests.

## Verification
- `dotnet build --no-restore` — passed with one existing SQLite package vulnerability warning.
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter 'FullyQualifiedName~TryDecodeMinecraftFavicon' --verbosity minimal` — passed (7 tests).
- `dotnet test --no-restore --verbosity minimal` — 304 passed, 2 failed because this environment runs in .NET globalization-invariant mode and cannot load the existing `tr-TR` tests (tracked by #81).
- `git diff --check` — passed.

## Risk
- Low: valid favicon attachments are preserved; invalid favicon data now falls back to the existing status embed without an attachment.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
