### PR TITLE
fix: handle invalid images in deepfry

### DIFF
--- a/Modules/ImageModule.cs
+++ b/Modules/ImageModule.cs
@@ -14,6 +14,21 @@ public class ImageModule(CommandService commands, IServiceProvider serviceProvid
 {
     private static readonly HttpClient httpClient = new();
 
+    internal static bool TryDownscaleImage(byte[] imageData, out byte[] result)
+    {
+        try
+        {
+            result = ImageResizer.DownscaleIfTooLarge(imageData);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[IMAGE ERROR] Failed to inspect image: {ex}");
+            result = [];
+            return false;
+        }
+    }
+
     private readonly CommandService commands = commands;
     private readonly IServiceProvider serviceProvider = serviceProvider;
     private readonly DB dbContext = dbContext;
@@ -207,8 +222,23 @@ public class ImageModule(CommandService commands, IServiceProvider serviceProvid
             return;
         }
 
-        imageBytes = ImageResizer.DownscaleIfTooLarge(imageBytes);
-        byte[] deepfriedImage = ImageDeepFryer.DeepFry(imageBytes);
+        if (!TryDownscaleImage(imageBytes, out imageBytes))
+        {
+            await ReplyAsync("Failed to process the image. Please try again with a valid image file.");
+            return;
+        }
+
+        byte[] deepfriedImage;
+        try
+        {
+            deepfriedImage = ImageDeepFryer.DeepFry(imageBytes);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[DEEPFRY ERROR] Processing failed: {ex}");
+            await ReplyAsync("Failed to deepfry the image. Please try again with a different image.");
+            return;
+        }
 
         if (deepfriedImage == null || deepfriedImage.Length == 0)
         {

--- a/Morpheus.Tests/ImageModuleTests.cs
+++ b/Morpheus.Tests/ImageModuleTests.cs
@@ -1,0 +1,15 @@
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class ImageModuleTests
+{
+    [Fact]
+    public void TryDownscaleImage_ReturnsFalseForInvalidImageData()
+    {
+        bool result = ImageModule.TryDownscaleImage([0, 1, 2], out byte[] output);
+
+        Assert.False(result);
+        Assert.Empty(output);
+    }
+}


### PR DESCRIPTION
## Summary
- Prevent the `deepfry` command from failing on malformed or unsupported image bytes.
- Catch image inspection/processing errors and return a user-facing retry message instead of letting the command handler fail.
- Add a regression test for invalid image data.

## Verification
- `dotnet test --no-restore --filter FullyQualifiedName~ImageModuleTests --logger "console;verbosity=minimal"` — passed (1/1).
- `dotnet build --no-restore` — passed (0 errors; existing SDK/package warnings).
- `dotnet test --no-build --logger "console;verbosity=minimal"` — 298 passed, 2 failed in existing `MiscModuleTests` because this runner uses globalization-invariant mode and cannot load `tr-TR`.
- `git diff --check upstream/develop...HEAD` — passed.
- `dotnet format Morpheus.sln --verify-no-changes --no-restore` — failed on pre-existing repository-wide formatting violations outside this change.

## Risk
- Low: only changes error handling for the `deepfry` command; valid image processing remains unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
