### PR TITLE
fix: preserve Twitch state on API failure

### DIFF
--- a/Jobs/TwitchLiveJob.cs
+++ b/Jobs/TwitchLiveJob.cs
@@ -28,7 +28,14 @@ public class TwitchLiveJob(DB db, TwitchService twitch, DiscordWebhookService di
             return;
 
         List<string> userIds = subscriptions.Select(s => s.TwitchUserId).Distinct().ToList();
-        IReadOnlyDictionary<string, TwitchService.TwitchStream> live = await twitch.GetLiveStreamsAsync(userIds);
+        TwitchService.LiveStreamsResult result = await twitch.GetLiveStreamsResultAsync(userIds, context.CancellationToken);
+        if (!result.Succeeded)
+        {
+            logsService.Log("TwitchLiveJob: live-status request failed; preserving existing subscription state.", LogSeverity.Warning);
+            return;
+        }
+
+        IReadOnlyDictionary<string, TwitchService.TwitchStream> live = result.Streams;
 
         bool changed = false;
 

--- a/Morpheus.Tests/TwitchServiceTests.cs
+++ b/Morpheus.Tests/TwitchServiceTests.cs
@@ -35,6 +35,18 @@ public class TwitchServiceTests
         Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), duration);
     }
 
+    [Fact]
+    public async Task GetLiveStreamsResultAsync_WhenStreamsRequestFails_MarksResultAsUnknown()
+    {
+        using HttpClient httpClient = new(new StreamsFailureHandler());
+        TwitchService service = new(new LogsService(new LogQueue()), httpClient, "test-client", "test-secret");
+
+        TwitchService.LiveStreamsResult result = await service.GetLiveStreamsResultAsync(["123"]);
+
+        Assert.False(result.Succeeded);
+        Assert.Empty(result.Streams);
+    }
+
     private sealed class CancellationHandler(bool blockTokenRequest) : HttpMessageHandler
     {
         private readonly TaskCompletionSource requestStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -54,6 +66,25 @@ public class TwitchServiceTests
             requestStarted.SetResult();
             await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
             throw new InvalidOperationException("The canceled Twitch request unexpectedly completed.");
+        }
+    }
+
+    private sealed class StreamsFailureHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.RequestUri?.Host == "id.twitch.tv")
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"token\",\"expires_in\":3600}", Encoding.UTF8, "application/json")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = new StringContent("temporarily unavailable")
+            });
         }
     }
 }

--- a/Services/TwitchService.cs
+++ b/Services/TwitchService.cs
@@ -46,6 +46,7 @@ public class TwitchService
 
     public record TwitchUser(string Id, string Login, string DisplayName, string? ProfileImageUrl);
     public record TwitchStream(string Id, string Title);
+    public record LiveStreamsResult(IReadOnlyDictionary<string, TwitchStream> Streams, bool Succeeded);
 
     /// <summary>Resolves a Twitch login (handle) to its user, or null if not found / not configured.</summary>
     public async Task<TwitchUser?> GetUserAsync(string login, CancellationToken ct = default)
@@ -68,9 +69,19 @@ public class TwitchService
     /// </summary>
     public async Task<IReadOnlyDictionary<string, TwitchStream>> GetLiveStreamsAsync(IReadOnlyCollection<string> userIds, CancellationToken ct = default)
     {
+        LiveStreamsResult result = await GetLiveStreamsResultAsync(userIds, ct);
+        return result.Streams;
+    }
+
+    /// <summary>
+    /// Returns currently-live streams together with whether every Twitch request completed.
+    /// An unsuccessful result must not be interpreted as "everyone is offline" by polling jobs.
+    /// </summary>
+    public async Task<LiveStreamsResult> GetLiveStreamsResultAsync(IReadOnlyCollection<string> userIds, CancellationToken ct = default)
+    {
         Dictionary<string, TwitchStream> live = new();
         if (!IsConfigured || userIds.Count == 0)
-            return live;
+            return new LiveStreamsResult(live, true);
 
         // Helix allows up to 100 user_id params per request.
         foreach (string[] batch in userIds.Distinct().Chunk(100))
@@ -79,7 +90,7 @@ public class TwitchService
             string url = $"https://api.twitch.tv/helix/streams?{query}";
             HelixStreamsResponse? resp = await SendHelixAsync<HelixStreamsResponse>(url, ct);
             if (resp?.Data == null)
-                continue;
+                return new LiveStreamsResult(live, false);
 
             foreach (StreamPayload s in resp.Data)
             {
@@ -88,7 +99,7 @@ public class TwitchService
             }
         }
 
-        return live;
+        return new LiveStreamsResult(live, true);
     }
 
     private async Task<T?> SendHelixAsync<T>(string url, CancellationToken ct) where T : class


### PR DESCRIPTION
## Summary
- Distinguish Twitch API polling failures from a successful empty live-stream result.
- Preserve existing subscription live state when Twitch status cannot be fetched, avoiding false offline transitions.
- Pass the Quartz cancellation token through the live-status request.

## Verification
- `dotnet restore Morpheus.sln` — passed with existing NU1903 SQLite vulnerability warning.
- `dotnet build Morpheus.sln --no-restore -v minimal` — passed with the same NU1903 warning.
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-build --no-restore --filter FullyQualifiedName~TwitchServiceTests -v minimal` — passed (7 tests).
- Full `dotnet test` — 298 passed, 2 failed; the same two invariant-globalization failures reproduce on unchanged `upstream/develop` (baseline: 297 passed, 2 failed).
- `dotnet format Morpheus.sln --no-restore --verify-no-changes` — skipped as a publish gate: the unchanged repository has broad pre-existing CRLF/import/final-newline violations.

## Risk
- Low: failed Twitch polling now leaves state untouched for the next scheduled poll; successful responses retain existing behavior.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
