### PR TITLE
fix: retain reminders when channels are unavailable

### DIFF
--- a/Jobs/RemindersJob.cs
+++ b/Jobs/RemindersJob.cs
@@ -53,12 +53,6 @@ public class RemindersJob(LogsService logsService, DB dB, DiscordSocketClient di
         Action<string> log,
         DateTime now)
     {
-        if (sendAsync == null)
-        {
-            log($"Channel {reminder.ChannelId} not found, deleting reminder {reminder.Id}.");
-            return true;
-        }
-
         if (reminder.FirstDeliveryFailureAt.HasValue &&
             now >= reminder.FirstDeliveryFailureAt.Value.Add(MaximumRetryAge))
         {
@@ -66,6 +60,16 @@ public class RemindersJob(LogsService logsService, DB dB, DiscordSocketClient di
                 $"Reminder {reminder.Id} to channel {reminder.ChannelId} permanently failed " +
                 $"after {reminder.DeliveryFailureCount} delivery attempts over one week. Deleting reminder.");
             return true;
+        }
+
+        if (sendAsync == null)
+        {
+            ScheduleRetry(
+                reminder,
+                now,
+                log,
+                $"Channel {reminder.ChannelId} is unavailable for reminder {reminder.Id}");
+            return false;
         }
 
         string content = string.IsNullOrWhiteSpace(reminder.Text) ? "Reminder!" : reminder.Text;
@@ -78,18 +82,25 @@ public class RemindersJob(LogsService logsService, DB dB, DiscordSocketClient di
         }
         catch (Exception ex)
         {
-            reminder.FirstDeliveryFailureAt ??= now;
-            reminder.DeliveryFailureCount++;
-
-            DateTime retryDeadline = reminder.FirstDeliveryFailureAt.Value.Add(MaximumRetryAge);
-            DateTime nextAttempt = now.Add(CalculateRetryDelay(reminder.DeliveryFailureCount));
-            reminder.NextDeliveryAttemptAt = nextAttempt < retryDeadline ? nextAttempt : retryDeadline;
-
-            log(
-                $"Error sending reminder {reminder.Id} to channel {reminder.ChannelId}: {ex.Message}. " +
-                $"Retry {reminder.DeliveryFailureCount} scheduled for {reminder.NextDeliveryAttemptAt:u}.");
+            ScheduleRetry(
+                reminder,
+                now,
+                log,
+                $"Error sending reminder {reminder.Id} to channel {reminder.ChannelId}: {ex.Message}");
             return false;
         }
+    }
+
+    private static void ScheduleRetry(Reminder reminder, DateTime now, Action<string> log, string failure)
+    {
+        reminder.FirstDeliveryFailureAt ??= now;
+        reminder.DeliveryFailureCount++;
+
+        DateTime retryDeadline = reminder.FirstDeliveryFailureAt.Value.Add(MaximumRetryAge);
+        DateTime nextAttempt = now.Add(CalculateRetryDelay(reminder.DeliveryFailureCount));
+        reminder.NextDeliveryAttemptAt = nextAttempt < retryDeadline ? nextAttempt : retryDeadline;
+
+        log($"{failure}. Retry {reminder.DeliveryFailureCount} scheduled for {reminder.NextDeliveryAttemptAt:u}.");
     }
 
     internal static TimeSpan CalculateRetryDelay(int failureCount)

--- a/Morpheus.Tests/RemindersJobTests.cs
+++ b/Morpheus.Tests/RemindersJobTests.cs
@@ -45,6 +45,26 @@ public class RemindersJobTests
         Assert.Equal(["Remember this"], sentMessages);
     }
 
+    [Fact]
+    public async Task DeliverAsync_WhenChannelUnavailable_RetainsReminderForRetry()
+    {
+        Reminder reminder = new() { Id = 7, ChannelId = 42, Text = "Remember this" };
+        List<string> logs = [];
+        DateTime now = new(2026, 7, 31, 8, 0, 0, DateTimeKind.Utc);
+
+        bool shouldDelete = await RemindersJob.DeliverAsync(
+            reminder,
+            null,
+            logs.Add,
+            now);
+
+        Assert.False(shouldDelete);
+        Assert.Equal(1, reminder.DeliveryFailureCount);
+        Assert.Equal(now, reminder.FirstDeliveryFailureAt);
+        Assert.Equal(now.AddMinutes(1), reminder.NextDeliveryAttemptAt);
+        Assert.Contains(logs, message => message.Contains("unavailable") && message.Contains("Retry 1 scheduled"));
+    }
+
     [Theory]
     [InlineData(1, 1)]
     [InlineData(2, 2)]


### PR DESCRIPTION
## Summary
- Keep reminders when the Discord channel is temporarily unavailable from the client cache.
- Record the miss through the existing bounded retry/backoff policy instead of deleting the reminder immediately.
- Share retry scheduling between unavailable-channel and send-failure paths, with regression coverage.

## Verification
- `dotnet restore Morpheus.sln` — passed; existing NU1903 SQLitePCLRaw.lib.e_sqlite3 vulnerability warning.
- `dotnet build Morpheus.sln --no-restore --verbosity minimal` — passed (0 errors; same NU1903 warning).
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-build --filter FullyQualifiedName~RemindersJobTests --verbosity minimal` — passed (10/10).
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-build --verbosity minimal` — 298/300 passed; two pre-existing `tr-TR` globalization-invariant failures in `MiscModuleTests`.
- `git diff --check upstream/develop...HEAD` — passed.
- Sabotage check: temporarily restored immediate-delete behavior; the new regression test failed, then the fix was restored and focused tests passed.

## Risk
- Low: changes are limited to reminder delivery retry bookkeeping and its focused tests. No schema changes.

Closes #111

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
