### PR TITLE
fix: preserve fractional activity level calculation

### DIFF
--- a/Morpheus.Tests/ActivityLevelServiceTests.cs
+++ b/Morpheus.Tests/ActivityLevelServiceTests.cs
@@ -9,6 +9,8 @@ public class ActivityLevelServiceTests
     [InlineData(998, 0)]
     [InlineData(999, 1)]
     [InlineData(1000, 1)]
+    [InlineData(1449, 1)]
+    [InlineData(1450, 2)]
     public void CalculateLevel_ReturnsExpectedBoundaryLevels(long xp, int expectedLevel)
     {
         Assert.Equal(expectedLevel, ActivityLevelService.CalculateLevel(xp));

--- a/Services/ActivityLevelService.cs
+++ b/Services/ActivityLevelService.cs
@@ -68,7 +68,7 @@ public class ActivityLevelService(DB dbContext)
 
     public static int CalculateLevel(long xp)
     {
-        return (int)Math.Pow(Math.Log10((xp + 111) / 111), 5.0243);
+        return (int)Math.Pow(Math.Log10((xp + 111d) / 111d), 5.0243);
     }
 
     public static int CalculateXp(int level)


### PR DESCRIPTION
## Summary
- Preserve the fractional part of the activity-level formula instead of truncating the ratio through integer division.
- Add regression boundaries around the affected level transition.

## Verification
- `dotnet restore` — passed (existing NU1903 vulnerability warning).
- `dotnet build --no-restore` — passed (existing NU1903 vulnerability warning).
- `dotnet test --no-restore --filter FullyQualifiedName~ActivityLevelServiceTests` — passed (13 tests).
- `dotnet test --no-restore --filter 'FullyQualifiedName!~NormalizeTimeUntilEventName'` — passed (299 tests).
- `dotnet test --no-restore` — failed only because the environment is globalization-invariant and two pre-existing tests require `tr-tr`; all other 299 tests passed.
- `git diff --check` — passed.

## Risk
- Low: this changes only the numeric precision used by `CalculateLevel`; the regression tests cover the corrected boundary.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
