### PR TITLE
fix: trim rock paper scissors input

### DIFF
--- a/Modules/MiscModule.cs
+++ b/Modules/MiscModule.cs
@@ -349,7 +349,7 @@ public class MiscModule(CommandService commands, IServiceProvider serviceProvide
         }
     }
 
-    internal static string NormalizeRockPaperScissorsChoice(string choice) => choice.ToLowerInvariant();
+    internal static string NormalizeRockPaperScissorsChoice(string choice) => choice.Trim().ToLowerInvariant();
 
     [Name("Info")]
     [Summary("Displays information about the bot.")]

--- a/Morpheus.Tests/MiscModuleTests.cs
+++ b/Morpheus.Tests/MiscModuleTests.cs
@@ -53,7 +53,7 @@ public class MiscModuleTests
     [Theory]
     [InlineData("ROCK", "rock")]
     [InlineData("PaPeR", "paper")]
-    [InlineData("ScIsSoRs", "scissors")]
+    [InlineData(" ScIsSoRs ", "scissors")]
     public void NormalizeRockPaperScissorsChoice_NormalizesMixedCase(string choice, string expected)
     {
         Assert.Equal(expected, MiscModule.NormalizeRockPaperScissorsChoice(choice));


### PR DESCRIPTION
## Summary
- Trim surrounding whitespace before the existing invariant case normalization for Rock Paper Scissors choices.
- Extend the existing regression coverage with padded mixed-case input.

## Verification
- `dotnet restore Morpheus.sln` — passed (existing NU1903 warning).
- `dotnet build Morpheus.sln --no-restore` — passed with 0 errors.
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-build --filter FullyQualifiedName~NormalizeRockPaperScissorsChoice` — passed (3/3).
- `dotnet test Morpheus.sln --no-build` — 297 passed; 2 unchanged `tr-TR` tests failed because this runner uses globalization-invariant mode.
- `git diff --check` — passed.

## Risk
- Low: valid choices retain existing behavior; only surrounding whitespace is newly accepted.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
