### PR TITLE
fix: preserve case-sensitive YouTube channel ids

### DIFF
--- a/Morpheus.Tests/SubscriptionInputParserTests.cs
+++ b/Morpheus.Tests/SubscriptionInputParserTests.cs
@@ -24,6 +24,17 @@ public class SubscriptionInputParserTests
     }
 
     [Fact]
+    public void ParseSources_PreservesDistinctCaseSensitiveYoutubeChannelIds()
+    {
+        SubscriptionInputParser.SourceList parsed = SubscriptionInputParser.ParseSources(
+            "UCaaaaaaaaaaaaaaaaaaaaaa UCaaaaaaaaaaaaaaaaaaaaaA");
+
+        Assert.Equal(
+            ["UCaaaaaaaaaaaaaaaaaaaaaa", "UCaaaaaaaaaaaaaaaaaaaaaA"],
+            parsed.Sources);
+    }
+
+    [Fact]
     public void ParseRssSources_PreservesLegacySingleFeedDisplayName()
     {
         IReadOnlyList<SubscriptionInputParser.RssSource> parsed =

--- a/Utilities/SubscriptionInputParser.cs
+++ b/Utilities/SubscriptionInputParser.cs
@@ -107,9 +107,24 @@ internal static partial class SubscriptionInputParser
         .Split(input)
         .Where(token => !string.IsNullOrWhiteSpace(token));
 
-    private static IReadOnlyList<string> Deduplicate(IEnumerable<string> values) => values
-        .Distinct(StringComparer.OrdinalIgnoreCase)
-        .ToArray();
+    private static IReadOnlyList<string> Deduplicate(IEnumerable<string> values)
+    {
+        List<string> unique = [];
+        HashSet<string> seenCaseSensitive = new(StringComparer.Ordinal);
+        HashSet<string> seenCaseInsensitive = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (string value in values)
+        {
+            HashSet<string> seen = YoutubeChannelIdRegex().IsMatch(value)
+                ? seenCaseSensitive
+                : seenCaseInsensitive;
+
+            if (seen.Add(value))
+                unique.Add(value);
+        }
+
+        return unique;
+    }
 
     private static bool IsHttpUrl(string value) =>
         Uri.TryCreate(value, UriKind.Absolute, out Uri? uri) &&
@@ -119,6 +134,9 @@ internal static partial class SubscriptionInputParser
 
     [GeneratedRegex("^<#(\\d+)>$")]
     private static partial Regex ChannelMentionRegex();
+
+    [GeneratedRegex("^UC[0-9A-Za-z_-]{22}$")]
+    private static partial Regex YoutubeChannelIdRegex();
 
     [GeneratedRegex(@"(?:\s*[,;]\s*|\s+)(?=https?://)", RegexOptions.IgnoreCase)]
     private static partial Regex RssUrlSeparatorRegex();


### PR DESCRIPTION
## Summary
- Preserve distinct case-sensitive YouTube channel IDs during bulk subscription parsing.
- Keep case-insensitive deduplication for Twitch handles and other subscription sources.
- Add regression coverage for IDs that differ only by letter case.

## Verification
- `dotnet restore` — passed; existing NU1903 SQLite advisory warning.
- `dotnet build --no-restore --nologo` — passed; 0 errors.
- `dotnet test --no-restore --filter FullyQualifiedName~SubscriptionInputParserTests --nologo` — passed; 21/21.
- `dotnet test --no-restore --nologo` — 298/300 passed; 2 pre-existing culture tests fail because the environment is globalization-invariant and lacks ICU when disabled.
- `dotnet format Morpheus.sln whitespace --no-restore --verify-no-changes` — failed on the repository-wide pre-existing CRLF/whitespace baseline; `git diff --check` passed.

## Risk
- Low: only bulk-source deduplication changes, with existing case-insensitive behavior retained for non-ID sources.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
