### PR TITLE
fix: tolerate concurrent channel creation

### DIFF
--- a/Morpheus.Tests/ChannelServiceConcurrencyTests.cs
+++ b/Morpheus.Tests/ChannelServiceConcurrencyTests.cs
@@ -1,0 +1,56 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class ChannelServiceConcurrencyTests
+{
+    [Fact]
+    public async Task TryGetCreateChannel_WhenAnotherHandlerCreatesChannel_ReturnsPersistedChannel()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using (DB setup = new(options))
+            await setup.Database.EnsureCreatedAsync();
+
+        await using RacingDb db = new(options);
+        db.InsertCompetingChannelOnNextSave = true;
+        ChannelService service = new(db, new LogsService(new LogQueue()));
+
+        Channel result = await service.TryGetCreateChannel(123, "current-name");
+
+        Assert.Equal((ulong)123, result.DiscordId);
+        Assert.Equal("current-name", result.Name);
+        Assert.Equal(1, await db.Channels.CountAsync());
+    }
+
+    private sealed class RacingDb(DbContextOptions<DB> options) : DB(options)
+    {
+        public bool InsertCompetingChannelOnNextSave { get; set; }
+
+        public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            if (InsertCompetingChannelOnNextSave)
+            {
+                InsertCompetingChannelOnNextSave = false;
+                ChangeTracker.Clear();
+                Channels.Add(new Channel
+                {
+                    DiscordId = 123,
+                    Name = "stale-name"
+                });
+                await base.SaveChangesAsync(cancellationToken);
+                throw new DbUpdateException("Simulated concurrent unique-key conflict.");
+            }
+
+            return await base.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/Services/ChannelService.cs
+++ b/Services/ChannelService.cs
@@ -28,7 +28,27 @@ public class ChannelService(DB dbContext, LogsService logsService)
         };
 
         await dbContext.Channels.AddAsync(channel);
-        await dbContext.SaveChangesAsync();
+        try
+        {
+            await dbContext.SaveChangesAsync();
+        }
+        catch (DbUpdateException)
+        {
+            // Another handler may have created the same Discord channel after our initial lookup.
+            // Clear the failed insert and use the row protected by the unique DiscordId index.
+            dbContext.ChangeTracker.Clear();
+            Channel? concurrentChannel = await dbContext.Channels.FirstOrDefaultAsync(c => c.DiscordId == discordId);
+            if (concurrentChannel == null)
+                throw;
+
+            if (concurrentChannel.Name != name)
+            {
+                concurrentChannel.Name = name;
+                await dbContext.SaveChangesAsync();
+            }
+
+            return concurrentChannel;
+        }
 
         logsService.Log($"New channel created {name}", Discord.LogSeverity.Verbose);
 


### PR DESCRIPTION
## Summary
- Handle the unique-key race when multiple handlers first observe the same Discord channel.
- Clear the failed insert, reload the winning row, and preserve the existing channel-name update behavior.
- Add a SQLite regression test that simulates a competing channel creation; no schema changes.

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter 'FullyQualifiedName~ChannelServiceConcurrencyTests'` — passed: 1/1 after the fix; the same test failed before the fix with the simulated `DbUpdateException`.
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter 'FullyQualifiedName~ChannelService'` — passed: 2/2.
- `dotnet build --no-restore` — passed: 0 errors; one existing NU1903 SQLite vulnerability warning.
- `dotnet format Morpheus.sln --no-restore --verify-no-changes --include Services/ChannelService.cs Morpheus.Tests/ChannelServiceConcurrencyTests.cs` — passed.
- `dotnet test --no-restore` — 298 passed, 2 failed: existing `MiscModuleTests.NormalizeTimeUntilEventName_NormalizesCase` cases cannot load `tr-TR` under this runner's globalization-invariant mode.
- `git diff --check` — passed.

## Risk
Low: the change only handles a database unique-key conflict during channel creation and reuses the existing unique `DiscordId` index; unrelated database errors are rethrown when no competing row is found.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.