### PR TITLE
fix: parse stock amounts invariantly

### DIFF
--- a/Modules/StocksModule.cs
+++ b/Modules/StocksModule.cs
@@ -116,7 +116,7 @@ public class StocksModule(DB dbContext, StocksService stocksService, ChannelServ
         decimal? sharesToSell = null;
         if (amountStr.ToLower() != "all")
         {
-            if (!decimal.TryParse(amountStr, out decimal parsed) || parsed <= 0)
+            if (!StockInputParser.TryParsePositiveAmount(amountStr, out decimal parsed))
             {
                 await ReplyAsync("Invalid amount. Use a positive number or `all`.");
                 return;
@@ -168,7 +168,7 @@ public class StocksModule(DB dbContext, StocksService stocksService, ChannelServ
         decimal? sharesToTransfer = null;
         if (amountStr.ToLower() != "all")
         {
-            if (!decimal.TryParse(amountStr, out decimal parsed) || parsed <= 0)
+            if (!StockInputParser.TryParsePositiveAmount(amountStr, out decimal parsed))
             {
                 await ReplyAsync("Invalid amount. Use a positive number or `all`.");
                 return;

--- a/Morpheus.Tests/StockInputParserTests.cs
+++ b/Morpheus.Tests/StockInputParserTests.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+using Morpheus.Utilities;
+
+namespace Morpheus.Tests;
+
+public class StockInputParserTests
+{
+    [Fact]
+    public void TryParsePositiveAmount_UsesInvariantDecimalSeparator()
+    {
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            culture.NumberFormat.NumberDecimalSeparator = ",";
+            culture.NumberFormat.NumberGroupSeparator = ".";
+            CultureInfo.CurrentCulture = culture;
+
+            bool parsed = StockInputParser.TryParsePositiveAmount("12.50", out decimal amount);
+
+            Assert.True(parsed);
+            Assert.Equal(12.50m, amount);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("0")]
+    [InlineData("-1")]
+    public void TryParsePositiveAmount_RejectsMissingAndNonPositiveValues(string? input)
+    {
+        Assert.False(StockInputParser.TryParsePositiveAmount(input, out _));
+    }
+}

--- a/Utilities/StockInputParser.cs
+++ b/Utilities/StockInputParser.cs
@@ -1,0 +1,11 @@
+using System.Globalization;
+
+namespace Morpheus.Utilities;
+
+internal static class StockInputParser
+{
+    public static bool TryParsePositiveAmount(string? input, out decimal amount)
+    {
+        return decimal.TryParse(input, NumberStyles.Number, CultureInfo.InvariantCulture, out amount) && amount > 0;
+    }
+}


### PR DESCRIPTION
## Summary
- Parse explicit stock sell and transfer amounts with invariant decimal semantics instead of the host process culture.
- Preserve the existing positive-amount validation and `all` behavior.
- Add regression coverage for decimal input under a comma-decimal culture and invalid amounts.

## Verification
- `dotnet restore Morpheus.sln` — passed; existing NU1903 SQLitePCLRaw.lib.e_sqlite3 vulnerability warning.
- `dotnet build Morpheus.sln --no-restore --nologo` — passed; 0 errors, same warning.
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter FullyQualifiedName~StockInputParserTests --nologo` — passed, 5/5.
- `dotnet test Morpheus.sln --no-restore --nologo --logger "console;verbosity=minimal"` — passed, 170/170.
- Targeted `dotnet format ... --verify-no-changes` for changed files — passed.
- Full repository `dotnet format` — blocked by the pre-existing CRLF/whitespace baseline in unrelated files; no formatting changes were applied.
- `git diff --check upstream/main...HEAD` — passed.

## Risk
- Low: only the parsing path for explicit stock sell/transfer amounts changes; stock buy's existing Discord command binding and the `all` path are unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
