### PR TITLE
fix: tolerate concurrent guild creation

### DIFF
--- a/Morpheus.Tests/GuildServiceConcurrencyTests.cs
+++ b/Morpheus.Tests/GuildServiceConcurrencyTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class GuildServiceConcurrencyTests
+{
+    [Fact]
+    public async Task TryGetCreateGuild_WhenAnotherHandlerCreatesGuild_ReturnsPersistedGuild()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using (DB setup = new(options))
+            await setup.Database.EnsureCreatedAsync();
+
+        await using RacingDb db = new(options);
+        db.InsertCompetingGuildOnNextSave = true;
+        GuildPrefixService prefixService = new(null!);
+        GuildService service = new(db, new LogsService(new LogQueue()), prefixService);
+
+        Guild result = await service.TryGetCreateGuild(123, "current-name");
+
+        Assert.Equal((ulong)123, result.DiscordId);
+        Assert.Equal("current-name", result.Name);
+        Assert.Equal("persisted-prefix", await prefixService.GetPrefixAsync(123));
+        Assert.Equal(1, await db.Guilds.CountAsync());
+
+        db.ChangeTracker.Clear();
+        Guild persistedGuild = await db.Guilds.SingleAsync();
+        Assert.Equal("current-name", persistedGuild.Name);
+    }
+
+    private sealed class RacingDb(DbContextOptions<DB> options) : DB(options)
+    {
+        public bool InsertCompetingGuildOnNextSave { get; set; }
+
+        public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            if (InsertCompetingGuildOnNextSave)
+            {
+                InsertCompetingGuildOnNextSave = false;
+                ChangeTracker.Clear();
+                Guilds.Add(new Guild
+                {
+                    DiscordId = 123,
+                    Name = "stale-name",
+                    Prefix = "persisted-prefix"
+                });
+                await base.SaveChangesAsync(cancellationToken);
+                throw new DbUpdateException("Simulated concurrent unique-key conflict.");
+            }
+
+            return await base.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/Services/GuildService.cs
+++ b/Services/GuildService.cs
@@ -4,6 +4,7 @@ using Morpheus.Database;
 using Morpheus.Database.Models;
 
 namespace Morpheus.Services;
+
 public class GuildService(DB dbContext, LogsService logsService, GuildPrefixService guildPrefixService)
 {
     public Task<Guild> TryGetCreateGuild(SocketGuild guild) =>
@@ -32,7 +33,28 @@ public class GuildService(DB dbContext, LogsService logsService, GuildPrefixServ
         };
 
         await dbContext.Guilds.AddAsync(guildDb);
-        await dbContext.SaveChangesAsync();
+        try
+        {
+            await dbContext.SaveChangesAsync();
+        }
+        catch (DbUpdateException)
+        {
+            // Another handler may have created the same Discord guild after our initial lookup.
+            // Clear the failed insert and use the row protected by the unique DiscordId index.
+            dbContext.ChangeTracker.Clear();
+            Guild? concurrentGuild = await dbContext.Guilds.FirstOrDefaultAsync(g => g.DiscordId == discordId);
+            if (concurrentGuild == null)
+                throw;
+
+            if (concurrentGuild.Name != name)
+            {
+                concurrentGuild.Name = name;
+                await dbContext.SaveChangesAsync();
+            }
+
+            guildPrefixService.SetPrefix(discordId, concurrentGuild.Prefix);
+            return concurrentGuild;
+        }
 
         logsService.Log($"New guild created {name}", Discord.LogSeverity.Verbose);
         guildPrefixService.SetPrefix(discordId, guildDb.Prefix);


### PR DESCRIPTION
## Summary
- Recover when concurrent handlers race to create the same Discord guild.
- Clear the failed EF insert and reload the row protected by the unique `DiscordId` index.
- Preserve the persisted prefix in the in-memory prefix cache.
- Add a SQLite regression test that reproduces the losing-insert path.

## Verification
- `dotnet restore Morpheus.sln --nologo` - passed (existing SQLite package advisory warning).
- `dotnet build Morpheus.sln --no-restore --nologo` - passed with 0 errors.
- Focused `GuildServiceConcurrencyTests` - passed, 1/1.
- Full `dotnet test` - 298 passed and the two pre-existing `tr-TR` globalization-invariant cases failed.
- Full suite excluding `NormalizeTimeUntilEventName_NormalizesCase` - passed, 298/298.
- Targeted `dotnet format ... --verify-no-changes` for both changed files - passed.
- `git diff --check upstream/develop...HEAD` - passed.

## Risk
Low. Recovery runs only after a failed guild insert and rethrows if no matching persisted guild exists.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
