### PR TITLE
fix: propagate webhook health job cancellation

### DIFF
--- a/Jobs/WebhookHealthJob.cs
+++ b/Jobs/WebhookHealthJob.cs
@@ -17,7 +17,8 @@ public class WebhookHealthJob(DB db, DiscordWebhookService discordWebhook, LogsS
 {
     public async Task Execute(IJobExecutionContext context)
     {
-        List<Webhook> webhooks = await db.Webhooks.ToListAsync();
+        CancellationToken cancellationToken = context.CancellationToken;
+        List<Webhook> webhooks = await db.Webhooks.ToListAsync(cancellationToken);
         if (webhooks.Count == 0)
             return;
 
@@ -26,7 +27,7 @@ public class WebhookHealthJob(DB db, DiscordWebhookService discordWebhook, LogsS
 
         foreach (Webhook webhook in webhooks)
         {
-            bool? exists = await discordWebhook.CheckExistsAsync(webhook.WebhookId, webhook.Token);
+            bool? exists = await discordWebhook.CheckExistsAsync(webhook.WebhookId, webhook.Token, cancellationToken);
 
             if (exists == false)
             {
@@ -44,7 +45,7 @@ public class WebhookHealthJob(DB db, DiscordWebhookService discordWebhook, LogsS
         }
 
         if (changed)
-            await db.SaveChangesAsync();
+            await db.SaveChangesAsync(cancellationToken);
 
         if (removed > 0)
             logsService.Log($"WebhookHealthJob: removed {removed} deleted webhook(s) and their subscriptions.");

--- a/Morpheus.Tests/WebhookHealthJobTests.cs
+++ b/Morpheus.Tests/WebhookHealthJobTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Jobs;
+using Morpheus.Services;
+using Quartz;
+using System.Reflection;
+
+namespace Morpheus.Tests;
+
+public class WebhookHealthJobTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WhenCanceledBeforeLoadingWebhooks_PropagatesCancellation()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB db = new(options);
+        await db.Database.EnsureCreatedAsync();
+
+        DiscordWebhookService discordWebhook = new(new LogsService(new LogQueue()));
+        WebhookHealthJob job = new(db, discordWebhook, new LogsService(new LogQueue()));
+        using CancellationTokenSource cancellation = new();
+        await cancellation.CancelAsync();
+
+        IJobExecutionContext context = CreateContext(cancellation.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => job.Execute(context));
+    }
+
+    private static IJobExecutionContext CreateContext(CancellationToken cancellationToken)
+    {
+        JobExecutionContextProxy.CurrentCancellationToken = cancellationToken;
+        return DispatchProxy.Create<IJobExecutionContext, JobExecutionContextProxy>();
+    }
+
+    private class JobExecutionContextProxy : DispatchProxy
+    {
+        public static CancellationToken CurrentCancellationToken { get; set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.ReturnType == typeof(CancellationToken))
+                return CurrentCancellationToken;
+
+            Type returnType = targetMethod?.ReturnType ?? typeof(void);
+            return returnType == typeof(void) || !returnType.IsValueType
+                ? null
+                : Activator.CreateInstance(returnType);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- propagate Quartz cancellation through WebhookHealthJob database loading, Discord existence checks, and persistence
- prevent shutdown from continuing webhook health checks after cancellation
- add a SQLite-backed regression test for cancellation before the webhook query

## Verification
- `dotnet restore Morpheus.sln` — passed; existing NU1903 warning for SQLitePCLRaw.lib.e_sqlite3
- focused RED test before implementation — failed as expected because cancellation was not propagated
- focused GREEN test after implementation — passed: 1/1
- `dotnet build Morpheus.sln --no-restore` — passed with 1 existing NU1903 warning and 0 errors
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore` — 298 passed, 2 baseline failures because invariant-globalization mode cannot load `tr-TR`
- filtered full suite excluding the known `tr-TR` cases — passed: 298/298
- `dotnet format Morpheus.sln --no-restore --include Jobs/WebhookHealthJob.cs Morpheus.Tests/WebhookHealthJobTests.cs` — passed
- targeted format verification with `--verify-no-changes` — passed
- `git diff --check upstream/develop...HEAD` — passed

## Risk
- Low: only threads the existing Quartz cancellation token through the health job's async operations; normal webhook checks and persistence are unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
