### PR TITLE
fix: restrict guild channel settings to text channels

### DIFF
--- a/Modules/GuildModule.cs
+++ b/Modules/GuildModule.cs
@@ -1,14 +1,14 @@
-﻿using Discord.Commands;
+﻿using Discord;
+using Discord.Commands;
 using Discord.WebSocket;
+using Microsoft.EntityFrameworkCore;
 using Morpheus.Attributes;
 using Morpheus.Database;
+using Morpheus.Database.Models;
 using Morpheus.Extensions;
 using Morpheus.Handlers;
-using Discord;
-using Morpheus.Utilities;
-using Morpheus.Database.Models;
-using Microsoft.EntityFrameworkCore;
 using Morpheus.Services;
+using Morpheus.Utilities;
 
 namespace Morpheus.Modules;
 
@@ -27,7 +27,7 @@ public class GuildModule(DiscordSocketClient client, CommandService commands, In
     [RequireUserPermission(Discord.GuildPermission.Administrator)]
     [RequireContext(ContextType.Guild)]
     [RateLimit(1, 10)]
-    public async Task SetWelcomeChanelAsync([Remainder] SocketChannel? channel = null)
+    public async Task SetWelcomeChanelAsync([Remainder] SocketTextChannel? channel = null)
     {
         // Load tracked Guild entity from DB instead of using Context.DbGuild (which may be detached)
         var guild = await dbContext.Guilds.FirstOrDefaultAsync(g => g.DiscordId == Context.Guild.Id);
@@ -94,7 +94,7 @@ public class GuildModule(DiscordSocketClient client, CommandService commands, In
     [RequireUserPermission(Discord.GuildPermission.Administrator)]
     [RequireContext(ContextType.Guild)]
     [RateLimit(1, 10)]
-    public async Task SetPinsChannelAsync([Remainder] SocketChannel? channel = null)
+    public async Task SetPinsChannelAsync([Remainder] SocketTextChannel? channel = null)
     {
         var guild = await dbContext.Guilds.FirstOrDefaultAsync(g => g.DiscordId == Context.Guild.Id);
         if (guild == null)
@@ -123,7 +123,7 @@ public class GuildModule(DiscordSocketClient client, CommandService commands, In
     [RequireUserPermission(Discord.GuildPermission.Administrator)]
     [RequireContext(ContextType.Guild)]
     [RateLimit(1, 10)]
-    public async Task SetLevelUpMessagesChannelAsync([Remainder] SocketChannel? channel = null)
+    public async Task SetLevelUpMessagesChannelAsync([Remainder] SocketTextChannel? channel = null)
     {
         var guild = await dbContext.Guilds.FirstOrDefaultAsync(g => g.DiscordId == Context.Guild.Id);
         if (guild == null)
@@ -151,7 +151,7 @@ public class GuildModule(DiscordSocketClient client, CommandService commands, In
     [RequireUserPermission(Discord.GuildPermission.Administrator)]
     [RequireContext(ContextType.Guild)]
     [RateLimit(1, 10)]
-    public async Task SetLevelUpQuotesChannelAsync([Remainder] SocketChannel? channel = null)
+    public async Task SetLevelUpQuotesChannelAsync([Remainder] SocketTextChannel? channel = null)
     {
         var guild = await dbContext.Guilds.FirstOrDefaultAsync(g => g.DiscordId == Context.Guild.Id);
         if (guild == null)
@@ -251,7 +251,7 @@ public class GuildModule(DiscordSocketClient client, CommandService commands, In
     [RequireUserPermission(Discord.GuildPermission.Administrator)]
     [RequireContext(ContextType.Guild)]
     [RateLimit(1, 10)]
-    public async Task SetQuotesApprovalChannel([Remainder] SocketChannel? channel = null)
+    public async Task SetQuotesApprovalChannel([Remainder] SocketTextChannel? channel = null)
     {
         var guild = await dbContext.Guilds.FirstOrDefaultAsync(g => g.DiscordId == Context.Guild.Id);
         if (guild == null)
@@ -346,7 +346,7 @@ public class GuildModule(DiscordSocketClient client, CommandService commands, In
     [RequireBotPermission(GuildPermission.BanMembers)]
     [RequireContext(ContextType.Guild)]
     [RateLimit(1, 10)]
-    public async Task SetHoneypotChannelAsync([Remainder] SocketChannel? channel = null)
+    public async Task SetHoneypotChannelAsync([Remainder] SocketTextChannel? channel = null)
     {
         var guild = await dbContext.Guilds.FirstOrDefaultAsync(g => g.DiscordId == Context.Guild.Id);
         if (guild == null)

--- a/Morpheus.Tests/GuildModuleTests.cs
+++ b/Morpheus.Tests/GuildModuleTests.cs
@@ -1,0 +1,28 @@
+using Discord.WebSocket;
+using Morpheus.Modules;
+using System.Reflection;
+
+namespace Morpheus.Tests;
+
+public class GuildModuleTests
+{
+    public static TheoryData<string> ChannelConfigurationMethods =>
+    [
+        nameof(GuildModule.SetWelcomeChanelAsync),
+        nameof(GuildModule.SetPinsChannelAsync),
+        nameof(GuildModule.SetLevelUpMessagesChannelAsync),
+        nameof(GuildModule.SetLevelUpQuotesChannelAsync),
+        nameof(GuildModule.SetQuotesApprovalChannel),
+        nameof(GuildModule.SetHoneypotChannelAsync)
+    ];
+
+    [Theory]
+    [MemberData(nameof(ChannelConfigurationMethods))]
+    public void ChannelConfigurationCommands_AcceptOnlyTextChannels(string methodName)
+    {
+        MethodInfo method = typeof(GuildModule).GetMethod(methodName)!;
+        ParameterInfo channelParameter = method.GetParameters()[0];
+
+        Assert.Equal(typeof(SocketTextChannel), channelParameter.ParameterType);
+    }
+}


### PR DESCRIPTION
## Summary
- Restrict the six guild channel-setting commands to `SocketTextChannel` parameters.
- Prevent voice, stage, category, or other non-text channel selections from being persisted as destinations for text-based features.
- Add reflection-based regression coverage for every affected command parameter.

## Verification
- `dotnet restore Morpheus.sln --locked-mode` — passed; existing NU1903 SQLitePCLRaw.lib.e_sqlite3 advisory warning.
- Focused RED on untouched `upstream/develop` — passed as a valid failing test: 6/6 cases failed because the parameters were `SocketChannel` rather than `SocketTextChannel`.
- `dotnet build Morpheus.sln --no-restore --nologo --verbosity minimal` — passed, 0 errors; existing NU1903 warning.
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter 'FullyQualifiedName~GuildModuleTests'` — passed, 6/6.
- `dotnet test Morpheus.sln --no-restore --no-build` — 303 passed, 2 pre-existing failures in `MiscModuleTests.NormalizeTimeUntilEventName_NormalizesCase` because invariant-globalization mode cannot load `tr-TR`.
- Same full suite excluding `FullyQualifiedName~NormalizeTimeUntilEventName` — passed, 303/303.
- `dotnet format Morpheus.sln whitespace --no-restore --include Modules/GuildModule.cs Morpheus.Tests/GuildModuleTests.cs` — passed with workspace-load warnings.
- Targeted formatter verification with `--verify-no-changes` — passed with workspace-load warnings.
- `python3 tools/generate_commands_md.py` — completed; output differed only by existing platform path-separator normalization, so unrelated generated churn was excluded.
- `git diff --check upstream/develop...HEAD` and staged diff check — passed.

## Risk
- Low: only command parameter types change; valid text-channel selection and clearing behavior remain unchanged. No service, job, database, or network code is modified.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
