### PR TITLE
fix: prevent quote score aggregate overflow

### DIFF
--- a/Morpheus.Tests/QuoteServiceTests.cs
+++ b/Morpheus.Tests/QuoteServiceTests.cs
@@ -1,5 +1,5 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 using Morpheus.Database;
 using Morpheus.Database.Models;
 using Morpheus.Services;
@@ -177,6 +177,31 @@ public class QuoteServiceTests
 
         Assert.Equal(quotes.Take(QuoteService.PageSize).Select(quote => quote.Id), firstPage.Items.Select(item => item.Id));
         Assert.Equal([quotes[^1].Id], secondPage.Items.Select(item => item.Id));
+    }
+
+    [Fact]
+    public async Task QuoteScoreAggregates_WidenBeforeSummingAndClampPublicTotals()
+    {
+        await using SqliteTestDb testDb = await CreateSqliteDbAsync();
+        (User user, Guild guild) = await SeedUserAndGuildAsync(testDb.Db);
+        User secondUser = new() { DiscordId = 789, Username = "second" };
+        await testDb.Db.Users.AddAsync(secondUser);
+        await testDb.Db.SaveChangesAsync();
+
+        Quote quote = await SeedQuoteAsync(testDb.Db, guild, user, approved: true, content: "high score");
+        testDb.Db.QuoteScores.AddRange(
+            new QuoteScore { QuoteId = quote.Id, UserId = user.Id, Score = int.MaxValue },
+            new QuoteScore { QuoteId = quote.Id, UserId = secondUser.Id, Score = 1 });
+        await testDb.Db.SaveChangesAsync();
+
+        QuoteService service = new(testDb.Db);
+
+        QuoteDetails details = await service.GetQuoteDetailsAsync(quote.Id)
+            ?? throw new InvalidOperationException("Quote details were not found.");
+        QuotePage page = await service.GetQuotePageAsync(1, "top", approvedOnly: true, guild.Id);
+
+        Assert.Equal(int.MaxValue, details.TotalScore);
+        Assert.Equal(int.MaxValue, Assert.Single(page.Items).Score);
     }
 
     [Fact]

--- a/Services/QuoteService.cs
+++ b/Services/QuoteService.cs
@@ -534,17 +534,24 @@ public class QuoteService(DB dbContext)
             .AsNoTracking()
             .Where(score => quoteIds.Contains(score.QuoteId))
             .GroupBy(score => score.QuoteId)
-            .Select(group => new { Id = group.Key, Score = group.Sum(score => score.Score) })
+            .Select(group => new { Id = group.Key, Score = group.Sum(score => (long)score.Score) })
             .ToListAsync();
 
-        return scores.ToDictionary(score => score.Id, score => score.Score);
+        return scores.ToDictionary(score => score.Id, score => ClampScore(score.Score));
     }
 
-    private async Task<int> GetTotalScoreAsync(int quoteId) =>
-        await dbContext.QuoteScores
+    private async Task<int> GetTotalScoreAsync(int quoteId)
+    {
+        long total = await dbContext.QuoteScores
             .AsNoTracking()
             .Where(score => score.QuoteId == quoteId)
-            .SumAsync(score => (int?)score.Score) ?? 0;
+            .SumAsync(score => (long?)score.Score) ?? 0L;
+
+        return ClampScore(total);
+    }
+
+    private static int ClampScore(long score) =>
+        (int)Math.Clamp(score, (long)int.MinValue, (long)int.MaxValue);
 
     internal IQueryable<Quote> ApplySort(IQueryable<Quote> quotesQuery, string sort) =>
         sort.ToLowerInvariant() switch
@@ -552,7 +559,7 @@ public class QuoteService(DB dbContext)
             "top" or "top-rated" or "toprated" => quotesQuery
                 .OrderByDescending(quote => dbContext.QuoteScores
                     .Where(score => score.QuoteId == quote.Id)
-                    .Sum(score => score.Score))
+                    .Sum(score => (long)score.Score))
                 .ThenBy(quote => quote.Id),
             "newest" => quotesQuery
                 .OrderByDescending(quote => quote.InsertDate)


### PR DESCRIPTION
## Summary
- widen quote-score database aggregates before summing so large totals do not overflow SQLite/PostgreSQL integer arithmetic
- clamp the existing public `int` score fields at the conversion boundary
- add a SQLite regression covering quote details, top-score sorting, and list totals above `Int32.MaxValue`

## Verification
- `dotnet restore Morpheus.sln --locked-mode` — passed; existing NU1903 SQLitePCLRaw advisory
- focused RED on untouched `upstream/develop` — failed with `OverflowException` for `Int32.MaxValue + 1`
- focused GREEN — passed (1 test)
- `dotnet build Morpheus.sln --no-restore --configuration Release` — passed
- focused `QuoteServiceTests` — passed (45 tests)
- full suite — 298 passed; the two unchanged `MiscModuleTests.NormalizeTimeUntilEventName_NormalizesCase` cases failed because this runner uses globalization-invariant mode and cannot load `tr-TR`
- changed-file `dotnet format --verify-no-changes` and `git diff --check` — passed

## Distinctness
- Complete repository history was searched; prior overflow work concerns activity XP, not quote-score aggregation.

## Risk
- Low: no schema or public API changes; only arithmetic width and clamping at existing `int` boundaries change.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
