### PR TITLE
fix: tolerate concurrent webhook persistence

### DIFF
--- a/Morpheus.Tests/WebhookServiceConcurrencyTests.cs
+++ b/Morpheus.Tests/WebhookServiceConcurrencyTests.cs
@@ -1,0 +1,94 @@
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Morpheus.Database;
+using Morpheus.Database.Models;
+using Morpheus.Services;
+using System.Reflection;
+
+namespace Morpheus.Tests;
+
+public class WebhookServiceConcurrencyTests
+{
+    [Fact]
+    public async Task GetOrCreateWebhookAsync_WhenAnotherHandlerCreatesWebhook_ReturnsPersistedWebhook()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using (DB setup = new(options))
+            await setup.Database.EnsureCreatedAsync();
+
+        await using RacingDb db = new(options);
+        db.InsertCompetingWebhookOnNextSave = true;
+        LogsService logs = new(new LogQueue());
+        WebhookService service = new(db, new DiscordSocketClient(), new DiscordWebhookService(logs), logs);
+        ITextChannel channel = DispatchProxy.Create<ITextChannel, TextChannelProxy>();
+
+        Webhook? result = await service.GetOrCreateWebhookAsync(channel);
+
+        Assert.NotNull(result);
+        Assert.Equal((ulong)123, result.ChannelDiscordId);
+        Assert.Equal((ulong)456, result.WebhookId);
+        Assert.Equal("token", result.Token);
+        Assert.Equal(1, await db.Webhooks.CountAsync());
+    }
+
+    private sealed class RacingDb(DbContextOptions<DB> options) : DB(options)
+    {
+        public bool InsertCompetingWebhookOnNextSave { get; set; }
+
+        public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            if (InsertCompetingWebhookOnNextSave)
+            {
+                InsertCompetingWebhookOnNextSave = false;
+                ChangeTracker.Clear();
+                Webhooks.Add(new Webhook
+                {
+                    GuildDiscordId = 789,
+                    ChannelDiscordId = 123,
+                    WebhookId = 456,
+                    Token = "token"
+                });
+                await base.SaveChangesAsync(cancellationToken);
+                throw new DbUpdateException("Simulated concurrent unique-key conflict.");
+            }
+
+            return await base.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private class TextChannelProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(ITextChannel.GetWebhooksAsync))
+                return Task.FromResult<IReadOnlyCollection<IWebhook>>(Array.Empty<IWebhook>());
+
+            if (targetMethod?.Name == nameof(ITextChannel.CreateWebhookAsync))
+                return Task.FromResult<IWebhook>(DispatchProxy.Create<IWebhook, WebhookProxy>());
+
+            return targetMethod?.ReturnType == typeof(ulong)
+                ? targetMethod.Name == "get_Id" ? (ulong)123 : (ulong)789
+                : targetMethod?.ReturnType == typeof(string) ? string.Empty
+                : targetMethod?.ReturnType is { IsValueType: true } type ? Activator.CreateInstance(type)
+                : null;
+        }
+    }
+
+    private class WebhookProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+            targetMethod?.Name switch
+            {
+                "get_Id" => (ulong)456,
+                "get_Token" => "token",
+                _ => targetMethod?.ReturnType is { IsValueType: true } type ? Activator.CreateInstance(type) : null
+            };
+    }
+}

--- a/Services/WebhookService.cs
+++ b/Services/WebhookService.cs
@@ -66,8 +66,23 @@ public class WebhookService(DB db, DiscordSocketClient client, DiscordWebhookSer
         };
 
         db.Webhooks.Add(created);
-        await db.SaveChangesAsync();
-        return created;
+
+        try
+        {
+            await db.SaveChangesAsync();
+            return created;
+        }
+        catch (DbUpdateException)
+        {
+            // Another handler may have inserted the unique channel row between our read and insert.
+            // Clear the failed insert before reloading the winner from the database.
+            db.ChangeTracker.Clear();
+            Webhook? competing = await db.Webhooks.FirstOrDefaultAsync(w => w.ChannelDiscordId == channel.Id);
+            if (competing == null)
+                throw;
+
+            return competing;
+        }
     }
 
     private async Task<IWebhook?> TryReuseExistingWebhookAsync(ITextChannel channel)


### PR DESCRIPTION
## Summary
- Recover the persisted webhook when concurrent handlers race on the unique per-channel webhook row.
- Clear the failed EF Core insert tracker before reloading the winner, while rethrowing when no competing row exists.

## Behavioral TDD
- RED on untouched `upstream/develop`: `WebhookServiceConcurrencyTests.GetOrCreateWebhookAsync_WhenAnotherHandlerCreatesWebhook_ReturnsPersistedWebhook` reached the assertion path and failed with the simulated `DbUpdateException`.
- GREEN after the fix: the focused test passes.

## Verification
- `dotnet restore Morpheus.sln` passed (NU1903 warning for SQLitePCLRaw.lib.e_sqlite3).
- `dotnet build Morpheus.sln --no-restore` passed (same NU1903 warning).
- Focused test passed: 1/1.
- `dotnet test Morpheus.sln --no-restore` ran 300 tests; 298 passed and 2 failed because this environment lacks ICU and uses invariant globalization, while the tests request `tr-tr`.
- `dotnet format ... --verify-no-changes` passed for the two changed files.
- `git diff --check` passed.

## Risk
The change is limited to handling a unique-key `DbUpdateException` during first-time webhook persistence. Other database failures are rethrown when no row can be reloaded. No schema or migration changes.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.