### PR TITLE
fix: validate quote approval interaction ids

### DIFF
--- a/Modules/QuotesModule.cs
+++ b/Modules/QuotesModule.cs
@@ -1,12 +1,13 @@
+using Discord;
 using Discord.Commands;
+using Discord.WebSocket;
 using Morpheus.Attributes;
 using Morpheus.Database.Models;
 using Morpheus.Extensions;
-using Morpheus.Utilities;
-using Discord.WebSocket;
-using Morpheus.Services;
 using Morpheus.Handlers;
-using Discord;
+using Morpheus.Services;
+using Morpheus.Utilities;
+using System.Globalization;
 
 namespace Morpheus.Modules;
 
@@ -31,6 +32,21 @@ public class QuotesModule : ModuleBase<SocketCommandContextExtended>
     }
 
     // Interaction handler for the approve button. Interaction custom id format: quote_approve:{approvalId}
+    internal static bool TryParseApprovalId(string? customId, out int approvalId)
+    {
+        approvalId = 0;
+        const string prefix = "quote_approve:";
+        if (string.IsNullOrEmpty(customId) || !customId.StartsWith(prefix, StringComparison.Ordinal))
+            return false;
+
+        ReadOnlySpan<char> value = customId.AsSpan(prefix.Length);
+        if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out int parsed) || parsed <= 0)
+            return false;
+
+        approvalId = parsed;
+        return true;
+    }
+
     private async Task HandleQuoteApproveInteraction(SocketInteraction interaction)
     {
         if (interaction is not SocketMessageComponent comp)
@@ -54,13 +70,10 @@ public class QuotesModule : ModuleBase<SocketCommandContextExtended>
             }
         }
 
-        if (!custom.StartsWith("quote_approve:"))
-        {
+        if (!custom.StartsWith("quote_approve:", StringComparison.Ordinal))
             return;
-        }
 
-        var parts = custom.Split(':', 2);
-        if (parts.Length < 2 || !int.TryParse(parts[1], out var approvalId))
+        if (!TryParseApprovalId(custom, out int approvalId))
         {
             await SafeRespond("Invalid approval identifier.");
             return;

--- a/Morpheus.Tests/QuoteApprovalInteractionTests.cs
+++ b/Morpheus.Tests/QuoteApprovalInteractionTests.cs
@@ -1,0 +1,26 @@
+using Morpheus.Modules;
+
+namespace Morpheus.Tests;
+
+public class QuoteApprovalInteractionTests
+{
+    [Theory]
+    [InlineData("quote_approve:42", true, 42)]
+    [InlineData("quote_approve:0", false, 0)]
+    [InlineData("quote_approve:-42", false, 0)]
+    [InlineData("quote_approve:+42", false, 0)]
+    [InlineData("quote_approve: 42", false, 0)]
+    [InlineData("quote_approve:42:extra", false, 0)]
+    [InlineData("quote_reject:42", false, 0)]
+    [InlineData(null, false, 0)]
+    public void TryParseApprovalId_RequiresUnsignedNonzeroInvariantComponentValue(
+        string? customId,
+        bool expectedSuccess,
+        int expectedApprovalId)
+    {
+        bool success = QuotesModule.TryParseApprovalId(customId, out int approvalId);
+
+        Assert.Equal(expectedSuccess, success);
+        Assert.Equal(expectedApprovalId, approvalId);
+    }
+}


### PR DESCRIPTION
## Summary
- Validate quote approval button custom IDs at the interaction boundary.
- Accept only the exact `quote_approve:<positive-integer>` shape using invariant, unsigned parsing.
- Reject forged, signed, whitespace-padded, zero, negative, and extra-segment values before approval lookup.
- Preserve silent handling of component IDs outside the `quote_approve:` route.

## TDD evidence
- RED on untouched behavior: focused test failed 4/8 cases because `int.TryParse` accepted zero, signed, and whitespace-padded IDs.
- GREEN: focused `QuoteApprovalInteractionTests` passed 8/8.

## Verification
- `dotnet restore Morpheus.sln --locked-mode` passed; NU1903 SQLite vulnerability warning reported separately.
- `dotnet build Morpheus.sln --no-restore` passed with 1 NU1903 warning.
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~QuoteApprovalInteractionTests --no-restore` passed: 8/8.
- `dotnet test Morpheus.sln --no-build --no-restore` ran 307 tests: 305 passed, 2 failed in the pre-existing `TimeUntil` culture cases (`CC BIRTHDAY`, `CHRISTMAS`) because ICU globalization data is unavailable in the invariant environment.
- `dotnet format Morpheus.sln --include Modules/QuotesModule.cs Morpheus.Tests/QuoteApprovalInteractionTests.cs --verify-no-changes --no-restore` passed.
- `git diff --check` passed.
- Command documentation generator ran; its output was restored because it only introduced unrelated Windows-to-Linux path separator churn.

## Risk
This is a narrow interaction-boundary validation change. Valid approval buttons generated by Morpheus remain unchanged.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.