### PR TITLE
fix: retry transient log persistence failures

### DIFF
--- a/Morpheus.Tests/LogsWriterServiceTests.cs
+++ b/Morpheus.Tests/LogsWriterServiceTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Morpheus.Database;
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class LogsWriterServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_RetriesBatchAfterTransientPersistenceFailure()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> options = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using DB observer = new(options);
+        await observer.Database.EnsureCreatedAsync();
+        FailureState failureState = new();
+
+        ServiceCollection services = new();
+        services.AddScoped<DB>(_ => new FailingDb(options, failureState));
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        LogQueue queue = new(capacity: 10);
+        LogsWriterService writer = new(queue, provider.GetRequiredService<IServiceScopeFactory>());
+        using CancellationTokenSource cancellation = new();
+
+        await writer.StartAsync(cancellation.Token);
+        Assert.True(queue.TryEnqueue(LogsService.CreateGeneralLog("retry me", Discord.LogSeverity.Warning)));
+
+        DateTime deadline = DateTime.UtcNow.AddSeconds(2);
+        while (DateTime.UtcNow < deadline && await observer.Logs.CountAsync() == 0)
+            await Task.Delay(20);
+
+        Assert.Equal(1, await observer.Logs.CountAsync());
+        Assert.Equal(
+            LogsService.FormatGeneralLog("retry me", Discord.LogSeverity.Warning),
+            (await observer.Logs.SingleAsync()).Message);
+
+        cancellation.Cancel();
+        await writer.StopAsync(CancellationToken.None);
+    }
+
+    private sealed class FailureState
+    {
+        public bool FailNextSave { get; set; } = true;
+    }
+
+    private sealed class FailingDb(DbContextOptions<DB> options, FailureState state) : DB(options)
+    {
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            if (state.FailNextSave)
+            {
+                state.FailNextSave = false;
+                throw new InvalidOperationException("transient persistence failure");
+            }
+
+            return base.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/Services/LogsWriterService.cs
+++ b/Services/LogsWriterService.cs
@@ -16,10 +16,8 @@ public sealed class LogsWriterService(LogQueue logQueue, IServiceScopeFactory sc
 
         try
         {
-            while (await logQueue.Reader.WaitToReadAsync(stoppingToken))
+            while (await WaitForBatchAsync(batch, stoppingToken))
             {
-                DrainAvailable(batch);
-
                 if (batch.Count < BatchSize)
                 {
                     try
@@ -33,7 +31,20 @@ public sealed class LogsWriterService(LogQueue logQueue, IServiceScopeFactory sc
                     DrainAvailable(batch);
                 }
 
-                await FlushAsync(batch, stoppingToken);
+                while (batch.Count > 0)
+                {
+                    if (await FlushAsync(batch, stoppingToken))
+                        break;
+
+                    try
+                    {
+                        await Task.Delay(BatchDelay, stoppingToken);
+                    }
+                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                }
             }
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
@@ -44,12 +55,22 @@ public sealed class LogsWriterService(LogQueue logQueue, IServiceScopeFactory sc
             while (true)
             {
                 DrainAvailable(batch);
-                if (batch.Count == 0)
+                if (batch.Count == 0 || !await FlushAsync(batch, CancellationToken.None))
                     break;
-
-                await FlushAsync(batch, CancellationToken.None);
             }
         }
+    }
+
+    private async Task<bool> WaitForBatchAsync(List<QueuedLog> batch, CancellationToken cancellationToken)
+    {
+        if (batch.Count > 0)
+            return true;
+
+        if (!await logQueue.Reader.WaitToReadAsync(cancellationToken))
+            return false;
+
+        DrainAvailable(batch);
+        return batch.Count > 0;
     }
 
     private void DrainAvailable(List<QueuedLog> batch)
@@ -58,10 +79,10 @@ public sealed class LogsWriterService(LogQueue logQueue, IServiceScopeFactory sc
             batch.Add(log);
     }
 
-    private async Task FlushAsync(List<QueuedLog> batch, CancellationToken cancellationToken)
+    private async Task<bool> FlushAsync(List<QueuedLog> batch, CancellationToken cancellationToken)
     {
         if (batch.Count == 0)
-            return;
+            return true;
 
         try
         {
@@ -72,6 +93,7 @@ public sealed class LogsWriterService(LogQueue logQueue, IServiceScopeFactory sc
 
             await dbContext.SaveChangesAsync(cancellationToken);
             batch.Clear();
+            return true;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -83,7 +105,7 @@ public sealed class LogsWriterService(LogQueue logQueue, IServiceScopeFactory sc
                 $"Failed to persist {batch.Count} queued log entries: {ex.Message}",
                 Discord.LogSeverity.Error));
 
-            batch.Clear();
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary
- Keep queued database logs in the active batch when a persistence attempt fails.
- Retry the batch after transient failures instead of silently dropping entries.
- Add a SQLite-backed regression test covering a failed first write followed by a successful retry.

## Verification
- `dotnet restore Morpheus.sln`
- `dotnet build Morpheus.sln --no-restore --configuration Debug`
- Focused RED: `LogsWriterServiceTests.ExecuteAsync_RetriesBatchAfterTransientPersistenceFailure` failed with 0 persisted logs on the pre-fix worker.
- Focused GREEN: 1 passed.
- Full suite: 298 passed, 2 pre-existing `tr-TR` invariant-globalization failures.
- `dotnet format ... --verify-no-changes` passed for changed files.
- `git diff --check` passed.

## Risk
Only the log writer retry path changes; a failed batch remains buffered until it can be persisted or shutdown is requested.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.