### PR TITLE
docs: clarify intentional activity level thresholds

### DIFF
--- a/Services/ActivityLevelService.cs
+++ b/Services/ActivityLevelService.cs
@@ -68,6 +68,8 @@ public class ActivityLevelService(DB dbContext)
 
     public static int CalculateLevel(long xp)
     {
+        // Integer division is intentional: it preserves the established XP thresholds.
+        // Do not use a floating-point ratio here without deliberately rebalancing levels.
         long normalizedXp = xp > long.MaxValue - 111
             ? (xp / 111) + 1
             : (xp + 111) / 111;


### PR DESCRIPTION
## Summary

- Document that integer division in `CalculateLevel` is intentional.
- Explain that switching to floating-point ratios would rebalance established XP thresholds.

## Why

Multiple proposed fixes have treated the integer division as an accidental precision loss. The current behavior is a deliberate game-balance decision and should be preserved unless levels are intentionally rebalanced.

## Verification

- `dotnet build Morpheus.sln --nologo`
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-build --nologo --filter FullyQualifiedName~ActivityLevelServiceTests` (13/13 passed)
