### PR TITLE
fix: preserve concurrent prefix updates

### DIFF
--- a/Morpheus.Tests/GuildPrefixServiceTests.cs
+++ b/Morpheus.Tests/GuildPrefixServiceTests.cs
@@ -1,0 +1,81 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Morpheus.Database;
+using Morpheus.Database.Models;
+using Morpheus.Services;
+
+namespace Morpheus.Tests;
+
+public class GuildPrefixServiceTests
+{
+    [Fact]
+    public async Task GetPrefixAsync_DoesNotOverwriteConcurrentPrefixUpdate()
+    {
+        await using SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        DbContextOptions<DB> setupOptions = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .Options;
+        await using (DB setup = new(setupOptions))
+        {
+            await setup.Database.EnsureCreatedAsync();
+            setup.Guilds.Add(new Guild
+            {
+                DiscordId = 123,
+                Name = "test-guild",
+                Prefix = "old!"
+            });
+            await setup.SaveChangesAsync();
+        }
+
+        BlockingQueryInterceptor interceptor = new();
+        DbContextOptions<DB> serviceOptions = new DbContextOptionsBuilder<DB>()
+            .UseSqlite(connection)
+            .AddInterceptors(interceptor)
+            .Options;
+        using ServiceProvider services = new ServiceCollection()
+            .AddScoped(_ => new DB(serviceOptions))
+            .BuildServiceProvider();
+        GuildPrefixService service = new(services.GetRequiredService<IServiceScopeFactory>());
+
+        Task<string> initialRead = service.GetPrefixAsync(123);
+        await interceptor.QueryStarted.WaitAsync(TimeSpan.FromSeconds(10));
+
+        service.SetPrefix(123, "new!");
+        interceptor.Release();
+
+        Assert.Equal("new!", await initialRead);
+        Assert.Equal("new!", await service.GetPrefixAsync(123));
+    }
+
+    private sealed class BlockingQueryInterceptor : DbCommandInterceptor
+    {
+        private readonly TaskCompletionSource<bool> queryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> releaseQuery = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int hasBlocked;
+
+        public Task QueryStarted => queryStarted.Task;
+
+        public void Release() => releaseQuery.TrySetResult(true);
+
+        public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (command.CommandText.Contains("Guilds", StringComparison.Ordinal)
+                && Interlocked.CompareExchange(ref hasBlocked, 1, 0) == 0)
+            {
+                queryStarted.TrySetResult(true);
+                await releaseQuery.Task.WaitAsync(cancellationToken);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Services/GuildPrefixService.cs
+++ b/Services/GuildPrefixService.cs
@@ -26,9 +26,7 @@ public class GuildPrefixService(IServiceScopeFactory scopeFactory)
             .FirstOrDefaultAsync()
             ?? DefaultPrefix;
 
-        prefixesByGuildId[guildDiscordId] = prefix;
-
-        return prefix;
+        return prefixesByGuildId.GetOrAdd(guildDiscordId, prefix);
     }
 
     public void SetPrefix(ulong guildDiscordId, string prefix)


### PR DESCRIPTION
## Summary
- prevent an in-flight prefix database lookup from overwriting a newer cached prefix set by an administrator
- add a deterministic regression test that pauses the database query while the cache is updated

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --filter FullyQualifiedName~GuildPrefixServiceTests --logger 'console;verbosity=minimal'` — passed: 1/1 (the regression failed against the unchanged implementation with `old!` instead of `new!`)
- `dotnet build` — passed with 0 errors; 2 existing NU1903 warnings for SQLitePCLRaw.lib.e_sqlite3 2.1.6
- `dotnet test --no-build --logger 'console;verbosity=minimal'` — passed: 429, skipped: 1, failed: 0
- `git diff --check` — passed

## Risk
- Low: the cache now keeps an entry written while an asynchronous database lookup is in flight; normal cache misses and explicit updates retain their existing behavior.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
