### PR TITLE
fix: retain RSS entries with blank GUIDs

### DIFF
--- a/Morpheus.Tests/RssFeedServiceTests.cs
+++ b/Morpheus.Tests/RssFeedServiceTests.cs
@@ -58,6 +58,27 @@ public class RssFeedServiceTests
     }
 
     [Fact]
+    public void ParseEntries_WhenGuidIsBlank_UsesLinkAsEntryId()
+    {
+        XDocument document = XDocument.Parse("""
+            <rss version="2.0">
+              <channel>
+                <item>
+                  <guid>   </guid>
+                  <title>Entry with blank guid</title>
+                  <link>https://example.com/posts/1</link>
+                  <pubDate>Wed, 30 Jul 2025 10:00:00 GMT</pubDate>
+                </item>
+              </channel>
+            </rss>
+            """);
+
+        RssFeedService.FeedEntry entry = Assert.Single(RssFeedService.ParseRssEntries(document));
+
+        Assert.Equal("https://example.com/posts/1", entry.EntryId);
+    }
+
+    [Fact]
     public async Task FetchAsync_WhenCallerCancels_PropagatesCancellation()
     {
         RssFeedService service = new(new LogsService(new LogQueue()));

--- a/Services/RssFeedService.cs
+++ b/Services/RssFeedService.cs
@@ -95,9 +95,10 @@ public class RssFeedService(LogsService logsService)
             string link = linkElement?.Value
                           ?? linkElement?.Attribute("href")?.Value
                           ?? string.Empty;
-            string id = ChildByLocalName(item, "guid")?.Value
-                        ?? ChildByLocalName(item, "id")?.Value
-                        ?? link;
+            string id = FirstNonBlank(
+                ChildByLocalName(item, "guid")?.Value,
+                ChildByLocalName(item, "id")?.Value,
+                link);
             string title = ChildByLocalName(item, "title")?.Value ?? string.Empty;
             string pubRaw = ChildByLocalName(item, "pubDate")?.Value
                             ?? ChildByLocalName(item, "published")?.Value
@@ -114,6 +115,9 @@ public class RssFeedService(LogsService logsService)
 
     private static XElement? ChildByLocalName(XElement parent, string localName) =>
         parent.Elements().FirstOrDefault(element => element.Name.LocalName == localName);
+
+    private static string FirstNonBlank(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? string.Empty;
 
     internal static DateTime ParsePublished(string value) =>
         DateTime.TryParse(


### PR DESCRIPTION
## Summary
- Keep RSS items when a present but blank `guid` would otherwise bypass the existing `id`/link fallback.
- Select and trim the first nonblank identifier in `guid` → `id` → link order.
- Add a regression test for an item with a blank GUID and valid link.

## Verification
- `dotnet test Morpheus.Tests/Morpheus.Tests.csproj --no-restore --filter FullyQualifiedName~RssFeedServiceTests --verbosity minimal` — passed: 8/8.
- `dotnet build --no-restore --verbosity minimal` — passed with 0 errors; existing NU1903 SQLitePCLRaw warning.
- `dotnet test --no-build --verbosity minimal` — passed: 429, skipped: 1, failed: 0.
- `git diff --check upstream/develop...HEAD` — passed.
- Regression RED check — the new focused test failed on the untouched parser because the item collection was empty.

## Risk
- Low: the change is limited to RSS item identifier selection and preserves the existing GUID, ID, then link precedence.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
