### PR TITLE
fix: serialize reminder delivery runs

### DIFF
--- a/Jobs/RemindersJob.cs
+++ b/Jobs/RemindersJob.cs
@@ -8,6 +8,7 @@ using Quartz;
 
 namespace Morpheus.Jobs;
 
+[DisallowConcurrentExecution]
 public class RemindersJob(LogsService logsService, DB dB, DiscordSocketClient discordClient) : IJob
 {
     internal static readonly TimeSpan MaximumRetryAge = TimeSpan.FromDays(7);

--- a/Morpheus.Tests/RemindersJobTests.cs
+++ b/Morpheus.Tests/RemindersJobTests.cs
@@ -1,10 +1,17 @@
 using Morpheus.Database.Models;
 using Morpheus.Jobs;
+using Quartz;
 
 namespace Morpheus.Tests;
 
 public class RemindersJobTests
 {
+    [Fact]
+    public void Job_DisallowsConcurrentDeliveryRuns()
+    {
+        Assert.True(typeof(RemindersJob).IsDefined(typeof(DisallowConcurrentExecutionAttribute), inherit: false));
+    }
+
     [Fact]
     public async Task DeliverAsync_WhenDeliveryFails_RetainsReminderForRetry()
     {


### PR DESCRIPTION
## Summary
- prevent overlapping Quartz reminder runs from delivering the same due reminder more than once
- add regression coverage requiring reminder delivery jobs to disallow concurrent execution

## Verification
- `dotnet build` — passed with 0 errors (2 existing NU1903 warnings)
- `dotnet test --filter 'FullyQualifiedName~RemindersJobTests' --logger 'console;verbosity=minimal'` — passed 11/11
- `dotnet test --no-build --logger 'console;verbosity=minimal'` — passed 429, skipped 1, failed 0
- `git diff --check` — passed

## Risk
- Low: this only serializes executions of the same Quartz reminder job and does not change reminder selection, delivery, or retry behavior.

This was generated by an AI agent (vycdev2). Please verify any changes before merging or applying.
